### PR TITLE
wizard: corrected signal name

### DIFF
--- a/src/gui/wizardform.ui
+++ b/src/gui/wizardform.ui
@@ -317,7 +317,7 @@ This field is mandatory.</string>
     </connection>
     <connection>
       <sender>authNameLineEdit</sender>
-      <signal>lostFocus()</signal>
+      <signal>editingFinished()</signal>
       <receiver>WizardForm</receiver>
       <slot>disableSuggestAuthName()</slot>
     </connection>


### PR DESCRIPTION
First of all ... many thanks reviving the twinkle GUI -> accidentaly found your work today and I'm glad to be using twinkle again.

This is just a small fix for the wizard ...