### PR TITLE
historyform: Fix sorting by time of event

### DIFF
--- a/src/gui/historyform.cpp
+++ b/src/gui/historyform.cpp
@@ -27,6 +27,7 @@
 #include "qicon.h"
 #include "audits/memman.h"
 #include "historyform.h"
+#include <QDateTime>
 
 #define HISTCOL_TIMESTAMP 	0
 #define HISTCOL_DIRECTION	1
@@ -174,8 +175,7 @@ void HistoryForm::loadHistory()
             {
                 case HISTCOL_TIMESTAMP:
                 {
-                    QString time = QString::fromStdString(time2str(cr->time_start,  "%d %b %Y %H:%M:%S"));
-                    m_model->setData(index, time);
+                    m_model->setData(index, QDateTime::fromTime_t(cr->time_start));
                     break;
                 }
                 case HISTCOL_DIRECTION:


### PR DESCRIPTION
When static date/time format was used for "time" column:
- sorting by "time" column was broken
- locale based format of date/time couldn't be enabled

=> use the QDateTime for "time" column and leave Qt handle the showed
format (based on locale)