### PR TITLE
Remove deprecated Encoding key from desktop file

### DIFF
--- a/twinkle.desktop.in
+++ b/twinkle.desktop.in
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=Twinkle
 GenericName=A SIP softphone
 Comment=A SIP softphone


### PR DESCRIPTION
I am packaging Twinkle 1.9 for Debian and received the following lintian warning:

https://lintian.debian.org/tags/desktop-entry-contains-encoding-key.html

The Encoding key is deprecated and all strings must be encoded in UTF-8.

http://standards.freedesktop.org/desktop-entry-spec/1.0/apc.html