### PR TITLE
Fix detection of <linux/errqueue.h>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ if (WITH_QT4 AND WITH_QT5)
 endif (WITH_QT4 AND WITH_QT5)
 
 include (CheckIncludeFile)
+include (CheckIncludeFiles)
 
 find_package(LibXml2 REQUIRED)
 find_package(LibMagic REQUIRED)
@@ -130,7 +131,7 @@ endif (WITH_GSM)
 
 check_include_file(unistd.h HAVE_UNISTD_H)
 check_include_file(linux/types.h HAVE_LINUX_TYPES_H)
-check_include_file(linux/errqueue.h HAVE_LINUX_ERRQUEUE_H)
+check_include_files("sys/time.h;linux/errqueue.h" HAVE_LINUX_ERRQUEUE_H)
 
 set(datadir "${CMAKE_INSTALL_PREFIX}/share/twinkle")
 configure_file(twinkle_config.h.in twinkle_config.h)


### PR DESCRIPTION
Linux ≥ 3.17 requires the definition of `struct timespec`.
```c
/* test.c */
#include <linux/errqueue.h>
```
```
cc -c test.c
In file included from test.c:1:0:
/usr/include/linux/errqueue.h:33:18: error: array type has incomplete element type ‘struct timespec’
  struct timespec ts[3];
                  ^
```
