### PR TITLE
historyform fixes

### DIFF
--- a/src/gui/historyform.cpp
+++ b/src/gui/historyform.cpp
@@ -79,8 +79,11 @@ void HistoryForm::init()
     m_model->setHorizontalHeaderLabels(QStringList() << tr("Time") << tr("In/Out") << tr("From/To") << tr("Subject") << tr("Status"));
     historyListView->horizontalHeader()->setSortIndicator(HISTCOL_TIMESTAMP, Qt::DescendingOrder);
 
-    historyListView->setColumnWidth(HISTCOL_FROMTO, 200);
-    historyListView->setColumnWidth(HISTCOL_SUBJECT, 200);
+#if QT_VERSION >= 0x050000
+    historyListView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+#else
+    historyListView->horizontalHeader()->setResizeMode(QHeaderView::ResizeToContents);
+#endif
 	
 	inCheckBox->setChecked(true);
 	outCheckBox->setChecked(true);

--- a/src/gui/historyform.cpp
+++ b/src/gui/historyform.cpp
@@ -125,6 +125,8 @@ void HistoryForm::loadHistory()
 	unsigned long totalCallDuration = 0;
 	unsigned long totalConversationDuration = 0;
 
+	m_model->setRowCount(0);
+
     std::list<t_call_record> history;
 
     call_history->get_history(history);

--- a/src/gui/historyform.cpp
+++ b/src/gui/historyform.cpp
@@ -77,7 +77,7 @@ void HistoryForm::init()
     m_model->setColumnCount(5);
 
     m_model->setHorizontalHeaderLabels(QStringList() << tr("Time") << tr("In/Out") << tr("From/To") << tr("Subject") << tr("Status"));
-    historyListView->sortByColumn(HISTCOL_TIMESTAMP, Qt::DescendingOrder);
+    historyListView->horizontalHeader()->setSortIndicator(HISTCOL_TIMESTAMP, Qt::DescendingOrder);
 
     historyListView->setColumnWidth(HISTCOL_FROMTO, 200);
     historyListView->setColumnWidth(HISTCOL_SUBJECT, 200);
@@ -228,6 +228,8 @@ void HistoryForm::loadHistory()
 	durationText += ")";
 	totalDurationValueTextLabel->setText(durationText);
 	
+	// Sort entries using currently selected sort column and order.
+	historyListView->sortByColumn(historyListView->horizontalHeader()->sortIndicatorSection(), historyListView->horizontalHeader()->sortIndicatorOrder());
 	// Make the first entry the selected entry.
     historyListView->selectRow(0);
 


### PR DESCRIPTION
Call QHeaderView::setSortIndicator() during initialization, which sets the sort column and order, but does not sort the (empty) table. After loading the history data call QTableView::sortByColumn() to sort the entries using the currently selected sort column and order.
