### PR TITLE
Fix conflicting definition of socklen_t on GNU Hurd

### DIFF
--- a/src/stun/udp.h
+++ b/src/stun/udp.h
@@ -2,7 +2,7 @@
 #define udp_h
 
 
-#ifdef __MACH__
+#if defined(__APPLE__) && defined(__MACH__)
 typedef int socklen_t;
 #endif
 


### PR DESCRIPTION
GNU Hurd and OS X both define `__MACH__`.

Test for `__APPLE__` to differentiate between GNU Hurd and OS X.