### PR TITLE
Fix race condition over deletion of sema_logview

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -350,11 +350,11 @@ void t_log::enable_inform_user(bool on) {
 		
 		if (!thr_logview) {
 			thr_logview = new t_thread(main_logview, NULL);
-			thr_logview->detach();
 		}
 	} else {
 		if (thr_logview) {
 			thr_logview->cancel();
+			thr_logview->join();
 			delete thr_logview;
 			thr_logview = NULL;
 		}


### PR DESCRIPTION
sema_logview may only be deleted after the logview thread has been
terminated, which can only be confirmed by joining with it.  (The return
of pthread_cancel() merely indicates that the cancellation request was
successfully queued.)

(This fixes #50.)