### PR TITLE
Case insensivity in digest authentication scheme

### DIFF
--- a/src/auth.cpp
+++ b/src/auth.cpp
@@ -134,7 +134,7 @@ bool t_auth::authorize(t_user *user_config, t_request *r, t_response *resp) {
 	}
 
 	// Only DIGEST is supported
-	if (c.auth_scheme != AUTH_DIGEST) {
+	if (cmp_nocase(c.auth_scheme, AUTH_DIGEST) != 0) {
 		log_file->write_header("t_auth::authorize");
 		log_file->write_raw("Unsupported authentication scheme: ");
 		log_file->write_raw(c.auth_scheme);

--- a/src/parser/challenge.cpp
+++ b/src/parser/challenge.cpp
@@ -163,7 +163,7 @@ string t_challenge::encode(void) const {
 	string s = auth_scheme;
 	s += ' ';
 
-	if (auth_scheme == AUTH_DIGEST) {
+	if (cmp_nocase(auth_scheme,AUTH_DIGEST) == 0) {
 		s += digest_challenge.encode();
 	} else {
 		for (list<t_parameter>::const_iterator i = auth_params.begin();

--- a/src/parser/credentials.cpp
+++ b/src/parser/credentials.cpp
@@ -143,7 +143,7 @@ string t_credentials::encode(void) const {
 	string s = auth_scheme;
 	s += ' ';
 
-	if (auth_scheme == AUTH_DIGEST) {
+	if (cmp_nocase(auth_scheme,AUTH_DIGEST) == 0) {
 		s += digest_response.encode();
 	} else {
 		for (list<t_parameter>::const_iterator i = auth_params.begin();

--- a/src/parser/scanner.lxx
+++ b/src/parser/scanner.lxx
@@ -302,7 +302,7 @@ WORD_SYM	[[:alnum:]\-\.!%\*_\+\`\'~\(\)<>:\\\"\/\[\]\?\{\}]
 <C_NEW>\n		{ return T_CRLF; }
 
 	/* Authorization scheme */
-<C_AUTH_SCHEME>Digest		{ return T_AUTH_DIGEST; }
+<C_AUTH_SCHEME>[Dd][Ii][Gg][Ee][Ss][Tt]	{ return T_AUTH_DIGEST; }
 <C_AUTH_SCHEME>{TOKEN_SYM}+ 	{ yylval.yyt_str = new string(yytext);
 			 	  MEMMAN_NEW(yylval.yyt_str);
 				  return T_AUTH_OTHER; }


### PR DESCRIPTION
Hi my improvements to digest authentication scheme - now twinkle works with BroadWorks.