### PR TITLE
Enclose gsm.h includes with extern C to resolve link failures

### DIFF
--- a/src/audio/audio_decoder.h
+++ b/src/audio/audio_decoder.h
@@ -26,7 +26,9 @@
 #include "user.h"
 
 #ifdef HAVE_GSM
+extern "C" {
 #include <gsm/gsm.h>
+}
 #else
 #include "gsm/inc/gsm.h"
 #endif

--- a/src/audio/audio_encoder.h
+++ b/src/audio/audio_encoder.h
@@ -26,7 +26,9 @@
 #include "user.h"
 
 #ifdef HAVE_GSM
+extern "C" {
 #include <gsm/gsm.h>
+}
 #else
 #include "gsm/inc/gsm.h"
 #endif


### PR DESCRIPTION
This patch resolves undefined reference errors due to gsm.h not having

    #ifdef __cplusplus
    extern "C" {
    #endif

in it's headers.
