### PR TITLE
Fix two issues with SelectUserForm

### DIFF
--- a/src/gui/selectuserform.cpp
+++ b/src/gui/selectuserform.cpp
@@ -96,7 +96,7 @@ void SelectUserForm::show(t_select_purpose purpose)
 	
 	// Fill list view
 	list<t_user *> user_list = phone->ref_users();
-	for (list<t_user *>::reverse_iterator i = user_list.rbegin(); i != user_list.rend(); i++) {
+	for (list<t_user *>::iterator i = user_list.begin(); i != user_list.end(); i++) {
         QListWidgetItem* item = new QListWidgetItem(QString::fromStdString((*i)->get_profile_name()), userListView);
 
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable);

--- a/src/gui/selectuserform.cpp
+++ b/src/gui/selectuserform.cpp
@@ -133,7 +133,6 @@ void SelectUserForm::validate()
 			not_selected_list.push_back(phone->
                 ref_user_profile(item->text().toStdString()));
 		}
-		i++;
 	}
 	
 	emit (selection(selected_list));


### PR DESCRIPTION
This fixes two issues with SelectUserForm:

- Only the selection of odd-numbered rows is acknowledged.
- The list of users is displayed in reverse order, for some unknown reason.