### PR TITLE
Fix two issues with multiple number conversion rules in UserProfileForm

### DIFF
--- a/src/gui/userprofileform.cpp
+++ b/src/gui/userprofileform.cpp
@@ -707,9 +707,9 @@ list<t_number_conversion> UserProfileForm::get_number_conversions()
 		t_number_conversion c;
 		
 		try {
-            item = conversionListView->item(0, 0);
+            item = conversionListView->item(i, 0);
             c.re.assign(item->text().toStdString());
-            item = conversionListView->item(0, 1);
+            item = conversionListView->item(i, 1);
             c.fmt = item->text().toStdString();
 			conversions.push_back(c);
         } catch (std::regex_error) {

--- a/src/gui/userprofileform.cpp
+++ b/src/gui/userprofileform.cpp
@@ -596,7 +596,7 @@ void UserProfileForm::populate()
     conversionListView->setRowCount(conversions.size());
 
     int j = 0;
-    for (list<t_number_conversion>::reverse_iterator i = conversions.rbegin(); i != conversions.rend(); i++, j++)
+    for (list<t_number_conversion>::iterator i = conversions.begin(); i != conversions.end(); i++, j++)
 	{
         QTableWidgetItem* item = new QTableWidgetItem(QString::fromStdString(i->re));
         conversionListView->setItem(j, 0, item);


### PR DESCRIPTION
This fixes two issues when defining more than one number conversion rule for a user profile:

- The contents of the first (or last) entry will overwrite all others.
- The list is displayed in reverse order, for some unknown reason.