### PR TITLE
User-Determined User Busy (UDUB)

### DIFF
--- a/src/line.cpp
+++ b/src/line.cpp
@@ -700,7 +700,7 @@ void t_line::reject(void) {
 	stop_timer(LTMR_NO_ANSWER);
 
 	try {
-		active_dialog->reject(R_603_DECLINE);
+		active_dialog->reject(R_486_BUSY_HERE);
 	}
 	catch (t_exception x) {
 		// TODO: there is no call to reject

--- a/src/userintf.cpp
+++ b/src/userintf.cpp
@@ -1565,7 +1565,7 @@ void t_userintf::do_help(const list<t_command_arg> &al) {
 		cout << "Usage:\n";
 		cout << "\treject\n";
 		cout << "Description:\n";
-		cout << "\tReject an incoming call. A 603 Decline response\n";
+		cout << "\tReject an incoming call. A 486 Busy Here response\n";
 		cout << "\twill be sent.\n";
 		cout << endl;
 


### PR DESCRIPTION
When you reject a call, either
A. the forwarding rule for User-Busy kicks in,
   like an answering machine or another extension (of a personal secretary or a deputy). Or
B. the caller hears normal ringing first, and then the busy tone.

To allow case A, a SIP user-agent client (UAC) has to return the status User-Busy (486). The same should happen in case B, because the caller shall hear a busy tone on rejection. 486 is mandated for SIP clients in mobile phones by the GSMA. Furthermore, other SIP-client creators give a 486 in that case as well; I tested Acrobits, Atlinks, Counterpath, Gigaset, Grandstream, RTX, Snom, Yealink, and Vtech.

Before this change, twinkle rejected a call with the SIP-Status 603. The class 6xx requires that *all* other registered phones stop to ring. Furthermore, some SIP user-agent servers (UAS) follow RFC 3398 and map a status 603 to the cause-code 21, which is mapped back to status 403 (Forbidden). Cisco and Digium Asterisk do this. For example in Asterisk, after you rejected the call in twinkle, the caller did not get 603 or 486, but 403. However, in case of 403, the original caller is allowed to re-try the call setup. For example, I have a Nokia Symbian/S60 based phone which tries via IPv4 first, then after it received the 403, that phone tries again via IPv6. Consequently, a user of twinkle had to reject the call twice when 603 was returned.