### PR TITLE
Disambiguate reference to ::bind()

### DIFF
--- a/src/sockets/socket.cpp
+++ b/src/sockets/socket.cpp
@@ -86,7 +86,7 @@ t_socket_udp::t_socket_udp() {
 	addr.sin_family = AF_INET;
 	addr.sin_addr.s_addr = htonl(INADDR_ANY);
 	addr.sin_port = htons(0);
-	ret = bind(sd, (struct sockaddr *)&addr, sizeof(addr));
+	ret = ::bind(sd, (struct sockaddr *)&addr, sizeof(addr));
 	if (ret < 0) throw errno;
 }
 
@@ -100,7 +100,7 @@ t_socket_udp::t_socket_udp(unsigned short port) {
 	addr.sin_family = AF_INET;
 	addr.sin_addr.s_addr = htonl(INADDR_ANY);
 	addr.sin_port = htons(port);
-	ret = bind(sd, (struct sockaddr *)&addr, sizeof(addr));
+	ret = ::bind(sd, (struct sockaddr *)&addr, sizeof(addr));
 	if (ret < 0) throw errno;
 }
 
@@ -295,7 +295,7 @@ t_socket_tcp::t_socket_tcp(unsigned short port) {
 	addr.sin_family = AF_INET;
 	addr.sin_addr.s_addr = htonl(INADDR_ANY);
 	addr.sin_port = htons(port);
-	ret = bind(sd, (struct sockaddr *)&addr, sizeof(addr));
+	ret = ::bind(sd, (struct sockaddr *)&addr, sizeof(addr));
 	if (ret < 0) throw errno;
 }
 

--- a/src/stun/udp.cxx
+++ b/src/stun/udp.cxx
@@ -64,7 +64,7 @@ openPort( unsigned short port, unsigned int interfaceIp, bool verbose )
       }
    }
 	
-   if ( bind( fd,(struct sockaddr*)&addr, sizeof(addr)) != 0 )
+   if ( ::bind( fd,(struct sockaddr*)&addr, sizeof(addr)) != 0 )
    {
       int e = getErrno();
         


### PR DESCRIPTION
There's a potential ambiguity between `::bind()` and `std::bind()` if
`<functional>` happens to be included beforehand (as is the case with
libc++).

---

It could be argued that getting rid of `using namespace std` would be the proper fix.  I have actually managed to do so (in a separate branch), but the changes are obviously much more intrusive than this simple patch.