### PR TITLE
Add compile-time check for C++11 regular expressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,14 @@ OPTION(WITH_GSM			"Use external GSM library" OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
+include (CheckCXX11Regex)
+check_cxx11_regex(HAVE_CXX11_REGEX)
+if (HAVE_CXX11_REGEX)
+	message(STATUS "C++11 regular expressions OK")
+else (HAVE_CXX11_REGEX)
+	message(FATAL_ERROR "C++11 regular expressions not supported!")
+endif (HAVE_CXX11_REGEX)
+
 include (CheckIncludeFile)
 include (CheckIncludeFiles)
 include (CheckSymbolExists)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Twinkle is a SIP-based VoIP client.
 
 To compile Twinkle you need the following libraries:
 
+* A standard library with C++11 support (at least version 4.9 for libstdc++)
 * ucommon [GNU uCommon C++](http://www.gnu.org/software/commoncpp/)
 * ccRTP (version >= 1.5.0) [GNU RTP Stack](http://www.gnu.org/software/ccrtp/)
 * libxml2

--- a/cmake/CheckCXX11Regex.cmake
+++ b/cmake/CheckCXX11Regex.cmake
@@ -1,0 +1,30 @@
+# Check if C++11 regular expressions are available and actually work.
+#
+# libstdc++ 4.8 shipped with a buggy prototype for C++11 regular expressions,
+# which barely supports the simplest cases, and will throw an exception at
+# pretty much anything else.  Unfortunately, this does not cause the build to
+# fail (since all the symbols are properly exported), and results instead in
+# mysterious runtime errors.  (See issue #31 for such an example.)
+
+include(CMakePushCheckState)
+include(CheckCXXSourceRuns)
+
+function(check_cxx11_regex result_var)
+	cmake_push_check_state()
+	set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
+
+	# With libstdc++ 4.8, this will compile but crash at runtime
+	check_cxx_source_runs("
+	    #include <regex>
+
+	    // Regex copied from Apple's SwiftCheckCXXNativeRegex.cmake
+	    const std::regex re(\"([a]+)\");
+
+	    int main() {
+	        return 0;
+	    }
+	" ${result_var})
+	set(${result_var} ${${result_var}} PARENT_SCOPE)
+
+	cmake_pop_check_state()
+endfunction()


### PR DESCRIPTION
[This will conflict with #152 ; once you've merged one of them, I can take care of rebasing the other.]

---

libstdc++ 4.8 shipped with a buggy prototype for C++11 regular expressions, which barely supports the simplest cases, and will throw an exception at pretty much anything else.  Unfortunately, this does not cause the build to fail (since all the symbols are properly exported), and results instead in mysterious runtime errors.  (See issue #31 for such an example.)

Closes #112

---

(I think this can also be considered to resolve #31.)