### PR TITLE
fix Qt 5.11 build (issue #124)

### DIFF
--- a/src/gui/diamondcardprofileform.cpp
+++ b/src/gui/diamondcardprofileform.cpp
@@ -21,6 +21,7 @@
 
 #include <QRegExp>
 #include <QValidator>
+#include <QRegExpValidator>
 #include "gui.h"
 #include "diamondcard.h"
 #include "getprofilenameform.h"

--- a/src/gui/getprofilenameform.cpp
+++ b/src/gui/getprofilenameform.cpp
@@ -1,7 +1,7 @@
 #include "getprofilenameform.h"
-
 #include <QDir>
 #include <QMessageBox>
+#include <QRegExpValidator>
 #include "user.h"
 #include "protocol.h"
 

--- a/src/gui/inviteform.cpp
+++ b/src/gui/inviteform.cpp
@@ -7,6 +7,7 @@
 #include "sys_settings.h"
 #include <QRegExp>
 #include <QValidator>
+#include <QRegExpValidator>
 
 /*
     Copyright (C) 2005-2009  Michel de Boer <michel@twinklephone.com>

--- a/src/gui/mphoneform.cpp
+++ b/src/gui/mphoneform.cpp
@@ -54,6 +54,7 @@
 #include <QRegExp>
 #include <QValidator>
 #include <QSettings>
+#include <QRegExpValidator>
 #include "buddyform.h"
 #include "diamondcardprofileform.h"
 #include "osd.h"

--- a/src/gui/numberconversionform.cpp
+++ b/src/gui/numberconversionform.cpp
@@ -1,5 +1,6 @@
 #include "numberconversionform.h"
 
+#include <QRegExpValidator>
 #include "gui.h"
 
 /*

--- a/src/gui/syssettingsform.cpp
+++ b/src/gui/syssettingsform.cpp
@@ -28,6 +28,7 @@
 #include "twinkle_config.h"
 #include <QRegExp>
 #include <QValidator>
+#include <QRegExpValidator>
 #include "syssettingsform.h"
 /*
  *  Constructs a SysSettingsForm as a child of 'parent', with the

--- a/src/gui/userprofileform.cpp
+++ b/src/gui/userprofileform.cpp
@@ -31,6 +31,7 @@
 #include <QStringList>
 #include "twinkle_config.h"
 #include <QListWidget>
+#include <QRegExpValidator>
 #include "numberconversionform.h"
 #include "util.h"
 #include "userprofileform.h"

--- a/src/gui/wizardform.cpp
+++ b/src/gui/wizardform.cpp
@@ -23,6 +23,7 @@
 #include <QTextStream>
 #include "gui.h"
 #include <QFile>
+#include <QRegExpValidator>
 #include "wizardform.h"
 
 #define PROV_NONE	QT_TRANSLATE_NOOP("WizardForm", "None (direct IP to IP calls)")


### PR DESCRIPTION
Since Qt 5.11, generated ui_getprofilename.h no longer includes QHeaderView
which breaks the chain that included qvalidator.h in getprofilename.cpp.
As it feels rather fragile to rely on such indirect includes, let's include
<QRegExpValidator> explicitly in each file using QRegExpValidator class.