### PR TITLE
Respond immediately to a "quit" command while in CLI mode

### DIFF
--- a/src/userintf.h
+++ b/src/userintf.h
@@ -62,6 +62,7 @@ protected:
 	
 private:
         bool            end_interface; // indicates if interface loop should quit
+        int             break_readline_loop_pipe[2]; // pipe used to interrupt Readline
         list<string>    all_commands;  // list of all commands
         t_tone_gen      *tone_gen;     // tone generator for ringing
         


### PR DESCRIPTION
When Twinkle is running in CLI mode and is sent a "quit" command to its local socket, it will currently not respond immediately, but rather wait until the next line has been read from its standard input, due to the blocking nature of `readline()`.

This pull request fixes this issue by switching to Readline's "alternate" callback interface, wrapping `select(2)` around that loop to avoid blocking on input, and using a self-pipe to break that loop upon reception of a "quit" command.

Closes #143