### PR TITLE
Systray icon: Always toggle visibility when clicking & Add "Show/Hide" menu entry

### DIFF
--- a/src/gui/mphoneform.cpp
+++ b/src/gui/mphoneform.cpp
@@ -3239,12 +3239,7 @@ void MphoneForm::whatsThis()
 void MphoneForm::sysTrayIconClicked(QSystemTrayIcon::ActivationReason reason)
 {
 	if (reason == QSystemTrayIcon::Trigger || reason == QSystemTrayIcon::DoubleClick)
-	{
-		if (sys_config->get_gui_hide_on_close())
-			setVisible(!isVisible());
-		else
-			activateWindow();
-	}
+		setVisible(!isVisible());
 }
 
 bool MphoneForm::event(QEvent * event)

--- a/src/gui/mphoneform.cpp
+++ b/src/gui/mphoneform.cpp
@@ -200,6 +200,12 @@ void MphoneForm::init()
 
 		connect(sysTray, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
 				this, SLOT(sysTrayIconClicked(QSystemTrayIcon::ActivationReason)));
+		connect(menu, &QMenu::aboutToShow, this, &MphoneForm::updateTrayIconMenu);
+
+		// Toggle window visibility
+		menu->addAction(toggleWindowAction);
+
+		menu->addSeparator();
 		
 		// Call menu
         menu->addAction(callInvite);
@@ -3239,7 +3245,20 @@ void MphoneForm::whatsThis()
 void MphoneForm::sysTrayIconClicked(QSystemTrayIcon::ActivationReason reason)
 {
 	if (reason == QSystemTrayIcon::Trigger || reason == QSystemTrayIcon::DoubleClick)
-		setVisible(!isVisible());
+		toggleWindow();
+}
+
+void MphoneForm::toggleWindow()
+{
+	setVisible(!isVisible());
+}
+
+void MphoneForm::updateTrayIconMenu()
+{
+	if (isVisible())
+		toggleWindowAction->setText(tr("Hide window"));
+	else
+		toggleWindowAction->setText(tr("Show window"));
 }
 
 bool MphoneForm::event(QEvent * event)

--- a/src/gui/mphoneform.h
+++ b/src/gui/mphoneform.h
@@ -172,6 +172,8 @@ public slots:
     void DiamondcardAdminCenter();
     void whatsThis();
 	void sysTrayIconClicked(QSystemTrayIcon::ActivationReason);
+	void toggleWindow();
+	void updateTrayIconMenu();
 
 	void osdMuteClicked();
 

--- a/src/gui/mphoneform.ui
+++ b/src/gui/mphoneform.ui
@@ -1822,6 +1822,11 @@
     <cstring>actgrActivateLine</cstring>
    </property>
   </actiongroup>
+  <action name="toggleWindowAction">
+   <property name="text">
+    <string>Toggle window visibility</string>
+   </property>
+  </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <tabstops>
@@ -2502,6 +2507,12 @@
      <y>301</y>
     </hint>
    </hints>
+  </connection>
+  <connection>
+   <sender>toggleWindowAction</sender>
+   <signal>triggered()</signal>
+   <receiver>MphoneForm</receiver>
+   <slot>toggleWindow()</slot>
   </connection>
  </connections>
  <slots>


### PR DESCRIPTION
This addresses both halves of issue #121 by:

- Fixing a bug where if "Hide in system tray when closing main window" was disabled, clicking on the system tray icon would not toggle visibility of the main window.
- Adding a "Show/Hide window" entry to the system tray icon menu.

Closes #121 