### PR TITLE
Prevent recursive locking of phone_users_mtx in add_phone_user()

### DIFF
--- a/src/phone.cpp
+++ b/src/phone.cpp
@@ -3054,7 +3054,7 @@ bool t_phone::add_phone_user(const t_user &user_config, t_user **dup_user) {
 		// Check if there is already another profile having
 		// the same contact name.
 		if (user->get_contact_name() == user_config.get_contact_name() &&
-		    USER_HOST(user, AUTO_IP4_ADDRESS) == USER_HOST(&user_config, AUTO_IP4_ADDRESS) &&
+		    phone->get_ip_sip_locked(user, AUTO_IP4_ADDRESS) == phone->get_ip_sip_locked(&user_config, AUTO_IP4_ADDRESS) &&
 		    (*i)->is_active())
 		{
 			*dup_user = user;
@@ -3160,9 +3160,13 @@ t_presence_epa *t_phone::ref_presence_epa(t_user *user) {
 }
 
 string t_phone::get_ip_sip(const t_user *user, const string &auto_ip) const {
+	t_rwmutex_reader x(phone_users_mtx);
+	return get_ip_sip_locked(user, auto_ip);
+}
+
+string t_phone::get_ip_sip_locked(const t_user *user, const string &auto_ip) const {
 	string result;
 
-	t_rwmutex_reader x(phone_users_mtx);
 	t_phone_user *pu = find_phone_user(user->get_profile_name());
 	if (pu) {
 		result = pu->get_ip_sip(auto_ip);

--- a/src/phone.h
+++ b/src/phone.h
@@ -256,6 +256,8 @@ protected:
 	 */
 	t_line *find_line_in_dialog_request(t_request *r, t_tid tid);
 
+	// Variation of get_ip_sip() for when phone_users_mtx is already locked
+	string get_ip_sip_locked(const t_user *user, const string &auto_ip) const;
 	// Events
 	void recvd_provisional(t_response *r, t_tuid tuid, t_tid tid);
 	void recvd_success(t_response *r, t_tuid tuid, t_tid tid);


### PR DESCRIPTION
When encountering two users with the same contact name, attempting to differentiate them using `USER_HOST()`, a.k.a. `get_ip_sip()`, would result in `EDEADLK` since `phone_users_mtx` was already locked by `add_phone_user()`.

Closes #88