### PR TITLE
Add support for the new bcg729 API, introduced in version 1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - FLAGS="-DWITH_QT5=ON -DWITH_ALSA=ON -DWITH_GSM=ON -DWITH_SPEEX=ON -DWITH_ZRTP=OFF"
     # (qttools5-dev-tools is explicitly included because of Debian bug #835295)
     - PACKAGES="libasound2-dev libgsm1-dev libspeex-dev libspeexdsp-dev qtdeclarative5-dev qttools5-dev qttools5-dev-tools"
+
   matrix:
     # Test various compiler versions
     - PACKAGES_ADD="g++-5"     MATRIX_EVAL="CC=gcc-5     && CXX=g++-5"
@@ -20,8 +21,14 @@ env:
     - PACKAGES_ADD="clang-6.0" MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
     - PACKAGES_ADD="clang-7"   MATRIX_EVAL="CC=clang-7   && CXX=clang++-7"
     - PACKAGES_ADD="clang-8"   MATRIX_EVAL="CC=clang-8   && CXX=clang++-8"
+
     # Test with all options disabled
     - FLAGS="-DWITH_QT5=OFF -DWITH_ALSA=OFF -DWITH_GSM=OFF -DWITH_SPEEX=OFF -DWITH_ZRTP=OFF" PACKAGES=""
+
+    # Test building with bcg729
+    - BUILD_BCG729="master" FLAGS="-DWITH_QT5=OFF -DWITH_ALSA=OFF -DWITH_G729=ON" PACKAGES="git ca-certificates"
+    # Also test the old pre-1.0.2 API (see issue #104)
+    - BUILD_BCG729="1.0.1" BUILD_BCG729_AUTOTOOLS="Y" FLAGS="-DWITH_QT5=OFF -DWITH_ALSA=OFF -DWITH_G729=ON" PACKAGES="git ca-certificates pkg-config libtool automake autoconf"
 
 # See https://docs.travis-ci.com/user/languages/cpp/#C11-C%2B%2B11-%28and-Beyond%29-and-Toolchain-Versioning
 before_install:
@@ -33,6 +40,8 @@ install:
   - sudo apt-get -y install bison cmake flex libccrtp-dev libmagic-dev libreadline-dev libsndfile1-dev libucommon-dev libxml2-dev linux-libc-dev $PACKAGES $PACKAGES_ADD
 
 script:
+  # Download and build bcg729 if necessary
+  - if [ "$BUILD_BCG729" ]; then git clone git://git.linphone.org/bcg729.git --branch "$BUILD_BCG729" && (cd bcg729 && if [ "$BUILD_BCG729_AUTOTOOLS" ]; then ./autogen.sh && ./configure; else cmake .; fi && make && sudo make install); fi
   - mkdir _build
   - cd _build
   - cmake -DCMAKE_INSTALL_PREFIX=../_install $FLAGS ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,10 @@ if (WITH_G729)
 	if (G729_FOUND)
 		message(STATUS "bcg729 OK")
 		set(HAVE_BCG729 TRUE)
+
+		if (G729_ANNEX_B)
+			set(HAVE_BCG729_ANNEX_B TRUE)
+		endif (G729_ANNEX_B)
 		
 		include_directories(${G729_INCLUDE_DIR})
 	else (G729_FOUND)

--- a/cmake/FindG729.cmake
+++ b/cmake/FindG729.cmake
@@ -1,14 +1,50 @@
+INCLUDE(CMakePushCheckState)
+INCLUDE(CheckCSourceCompiles)
+
 FIND_PATH(G729_INCLUDE_DIR bcg729/decoder.h)
 FIND_LIBRARY(G729_LIBRARY NAMES bcg729)
 
 IF(G729_INCLUDE_DIR AND G729_LIBRARY)
 	SET(G729_FOUND TRUE)
+
+	# The bcg729 API was changed in 1.0.2 to add support for G.729 Annex B.
+	# This checks whether we are dealing with the old or new API.
+	CMAKE_PUSH_CHECK_STATE()
+	SET(CMAKE_REQUIRED_INCLUDES "${INCLUDE_DIRECTORIES}" "${G729_INCLUDE_DIR}")
+	SET(CMAKE_REQUIRED_LIBRARIES "${G729_LIBRARY}")
+	SET(CMAKE_REQUIRED_QUIET TRUE)
+	# Try to compile something using the old (pre-1.0.2) API.
+	#
+	# We cannot do it the other way around, as initBcg729EncoderChannel()
+	# did not have a prototype before 1.0.2, thus compilation would not fail
+	# when passing it an extra argument.
+	CHECK_C_SOURCE_COMPILES("
+		#include <bcg729/encoder.h>
+
+		int main() {
+			/* This function requires an argument since 1.0.2 */
+			initBcg729EncoderChannel();
+			return 0;
+		}
+	" G729_OLD_API)
+	CMAKE_POP_CHECK_STATE()
+
+	IF (G729_OLD_API)
+		SET(G729_ANNEX_B FALSE)
+	ELSE (G729_OLD_API)
+		SET(G729_ANNEX_B TRUE)
+	ENDIF (G729_OLD_API)
 ENDIF(G729_INCLUDE_DIR AND G729_LIBRARY)
 
 IF(G729_FOUND)
 	IF (NOT G729_FIND_QUIETLY)
 		MESSAGE(STATUS "Found bcg729 includes:	${G729_INCLUDE_DIR}/bcg729/decoder.h")
 		MESSAGE(STATUS "Found bcg729 library: ${G729_LIBRARY}")
+		IF (G729_ANNEX_B)
+			MESSAGE(STATUS "bcg729 supports Annex B; using the new (1.0.2) API")
+		ELSE (G729_ANNEX_B)
+			MESSAGE(STATUS "bcg729 does not support Annex B; using the old (pre-1.0.2) API")
+		ENDIF (G729_ANNEX_B)
 	ENDIF (NOT G729_FIND_QUIETLY)
 ELSE(G729_FOUND)
 	IF (G729_FIND_REQUIRED)

--- a/src/audio/audio_decoder.cpp
+++ b/src/audio/audio_decoder.cpp
@@ -547,7 +547,11 @@ uint16 t_g729a_audio_decoder::decode(uint8 *payload, uint16 payload_size,
 
 	for (uint16 done = 0; done < payload_size; done += 10)
 	{
+#ifdef HAVE_BCG729_ANNEX_B
+		bcg729Decoder(_context, &payload[done], 0, false, false, false, &pcm_buf[done * 8]);
+#else
 		bcg729Decoder(_context, &payload[done], false, &pcm_buf[done * 8]);
+#endif
 	}
 
 	return payload_size * 8;
@@ -562,7 +566,11 @@ uint16 t_g729a_audio_decoder::conceal(int16 *pcm_buf, uint16 pcm_buf_size)
 {
 	assert(pcm_buf_size >= 80);
 
+#ifdef HAVE_BCG729_ANNEX_B
+	bcg729Decoder(_context, nullptr, 0, true, false, false, pcm_buf);
+#else
 	bcg729Decoder(_context, nullptr, true, pcm_buf);
+#endif
 	return 80;
 }
 

--- a/src/audio/audio_encoder.cpp
+++ b/src/audio/audio_encoder.cpp
@@ -433,7 +433,11 @@ uint16 t_g726_audio_encoder::encode(int16 *sample_buf, uint16 nsamples,
 t_g729a_audio_encoder::t_g729a_audio_encoder(uint16 payload_id, uint16 ptime, t_user *user_config)
 	: t_audio_encoder(payload_id, ptime, user_config)
 {
+#ifdef HAVE_BCG729_ANNEX_B
+	_context = initBcg729EncoderChannel(false);
+#else
 	_context = initBcg729EncoderChannel();
+#endif
 }
 
 t_g729a_audio_encoder::~t_g729a_audio_encoder()
@@ -451,7 +455,13 @@ uint16 t_g729a_audio_encoder::encode(int16 *sample_buf, uint16 nsamples,
 
 	for (uint16 done = 0; done < nsamples; done += 80)
 	{
+#ifdef HAVE_BCG729_ANNEX_B
+		uint8 frame_size = 10;
+		bcg729Encoder(_context, &sample_buf[done], &payload[done / 8], &frame_size);
+		assert(frame_size == 10);
+#else
 		bcg729Encoder(_context, &sample_buf[done], &payload[done / 8]);
+#endif
 	}
 
 	return nsamples / 8;

--- a/twinkle_config.h.in
+++ b/twinkle_config.h.in
@@ -4,6 +4,7 @@
 #cmakedefine HAVE_ILBC_CPP
 #cmakedefine HAVE_ZRTP
 #cmakedefine HAVE_BCG729
+#cmakedefine HAVE_BCG729_ANNEX_B
 #cmakedefine HAVE_GSM
 
 #cmakedefine HAVE_UNISTD_H


### PR DESCRIPTION
Starting with version 1.0.2, bcg729 has changed its API to add support for G.729B, thus requiring us to adjust our function calls depending on which version is installed.

This PR does the very minimal to keep using either version of bcg729 for G.729A as it was, and nothing more.  (Another PR will follow to prepare a possible introduction of G.729B.)  The goal was to make the reviewer's job as easy as possible, and minimize any chance for mistakes by making as few changes as possible.

~~Full disclosure: I did not test any of this.  (Oh, it does compile alright, but I don't have any way of using G.729A at the moment.)  The nature and simplicity of the changes make any bug very unlikely, but I felt I should state this fact nonetheless.  Any reviewers/testers would be appreciated.~~

Closes #104 