### PR TITLE
(Almost) add support for G.729 Annex B

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - FLAGS="-DWITH_QT5=ON -DWITH_ALSA=ON -DWITH_GSM=ON -DWITH_SPEEX=ON -DWITH_ZRTP=ON"
     # (qttools5-dev-tools is explicitly included because of Debian bug #835295)
     - PACKAGES="libasound2-dev libgsm1-dev libspeex-dev libspeexdsp-dev libzrtpcpp-dev qtdeclarative5-dev qttools5-dev qttools5-dev-tools"
+
   matrix:
     # Test various compiler versions
     - PACKAGES_ADD="g++-4.9" MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
@@ -15,8 +16,14 @@ env:
     # The version of uCommon available on trusty (6.0.7) will cause a build
     # failure when compiling with GCC 7 or Clang.
     #- PACKAGES_ADD="g++-7"   MATRIX_EVAL="CC=gcc-7   && CXX=g++-7"
+
     # Test with all options disabled
     - FLAGS="-DWITH_QT5=OFF -DWITH_ALSA=OFF -DWITH_GSM=OFF -DWITH_SPEEX=OFF -DWITH_ZRTP=OFF" PACKAGES=""
+
+    # Test building with bcg729
+    - BUILD_BCG729="master" FLAGS="-DWITH_QT5=OFF -DWITH_ALSA=OFF -DWITH_G729=ON" PACKAGES="git ca-certificates pkg-config libtool automake autoconf"
+    # Also test the old pre-1.0.2 API (see issue #104)
+    - BUILD_BCG729="1.0.1" FLAGS="-DWITH_QT5=OFF -DWITH_ALSA=OFF -DWITH_G729=ON" PACKAGES="git ca-certificates pkg-config libtool automake autoconf"
 
 # See https://docs.travis-ci.com/user/languages/cpp/#C11-C%2B%2B11-%28and-Beyond%29-and-Toolchain-Versioning
 before_install:
@@ -28,6 +35,8 @@ install:
   - sudo apt-get -y install bison cmake flex libccrtp-dev libmagic-dev libreadline-dev libsndfile1-dev libucommon-dev libxml2-dev linux-libc-dev $PACKAGES $PACKAGES_ADD
 
 script:
+  # Download and build bcg729 if necessary
+  - if [ "$BUILD_BCG729" ]; then git clone git://git.linphone.org/bcg729.git && (cd bcg729 && git checkout "$BUILD_BCG729" && ./autogen.sh && ./configure && make && sudo make install); fi
   - mkdir _build
   - cd _build
   - cmake -DCMAKE_INSTALL_PREFIX=../_install $FLAGS ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,10 @@ if (WITH_G729)
 	if (G729_FOUND)
 		message(STATUS "bcg729 OK")
 		set(HAVE_BCG729 TRUE)
+
+		if (G729_ANNEX_B)
+			set(HAVE_BCG729_ANNEX_B TRUE)
+		endif (G729_ANNEX_B)
 		
 		include_directories(${G729_INCLUDE_DIR})
 	else (G729_FOUND)

--- a/cmake/FindG729.cmake
+++ b/cmake/FindG729.cmake
@@ -1,14 +1,50 @@
+INCLUDE(CMakePushCheckState)
+INCLUDE(CheckCSourceCompiles)
+
 FIND_PATH(G729_INCLUDE_DIR bcg729/decoder.h)
 FIND_LIBRARY(G729_LIBRARY NAMES bcg729)
 
 IF(G729_INCLUDE_DIR AND G729_LIBRARY)
 	SET(G729_FOUND TRUE)
+
+	# The bcg729 API was changed in 1.0.2 to add support for G.729 Annex B.
+	# This checks whether we are dealing with the old or new API.
+	CMAKE_PUSH_CHECK_STATE()
+	SET(CMAKE_REQUIRED_INCLUDES "${INCLUDE_DIRECTORIES}" "${G729_INCLUDE_DIR}")
+	SET(CMAKE_REQUIRED_LIBRARIES "${G729_LIBRARY}")
+	SET(CMAKE_REQUIRED_QUIET TRUE)
+	# Try to compile something using the old (pre-1.0.2) API.
+	#
+	# We cannot do it the other way around, as initBcg729EncoderChannel()
+	# did not have a prototype before 1.0.2, thus compilation would not fail
+	# when passing it an extra argument.
+	CHECK_C_SOURCE_COMPILES("
+		#include <bcg729/encoder.h>
+
+		int main() {
+			/* This function requires an argument since 1.0.2 */
+			initBcg729EncoderChannel();
+			return 0;
+		}
+	" G729_OLD_API)
+	CMAKE_POP_CHECK_STATE()
+
+	IF (G729_OLD_API)
+		SET(G729_ANNEX_B FALSE)
+	ELSE (G729_OLD_API)
+		SET(G729_ANNEX_B TRUE)
+	ENDIF (G729_OLD_API)
 ENDIF(G729_INCLUDE_DIR AND G729_LIBRARY)
 
 IF(G729_FOUND)
 	IF (NOT G729_FIND_QUIETLY)
 		MESSAGE(STATUS "Found bcg729 includes:	${G729_INCLUDE_DIR}/bcg729/decoder.h")
 		MESSAGE(STATUS "Found bcg729 library: ${G729_LIBRARY}")
+		IF (G729_ANNEX_B)
+			MESSAGE(STATUS "bcg729 supports Annex B; using the new (1.0.2) API")
+		ELSE (G729_ANNEX_B)
+			MESSAGE(STATUS "bcg729 does not support Annex B; using the old (pre-1.0.2) API")
+		ENDIF (G729_ANNEX_B)
 	ENDIF (NOT G729_FIND_QUIETLY)
 ELSE(G729_FOUND)
 	IF (G729_FIND_REQUIRED)

--- a/src/audio/audio_decoder.cpp
+++ b/src/audio/audio_decoder.cpp
@@ -547,7 +547,11 @@ uint16 t_g729a_audio_decoder::decode(uint8 *payload, uint16 payload_size,
 
 	for (uint16 done = 0; done < payload_size; done += 10)
 	{
+#ifdef HAVE_BCG729_ANNEX_B
+		bcg729Decoder(_context, &payload[done], 0, false, false, false, &pcm_buf[done * 8]);
+#else
 		bcg729Decoder(_context, &payload[done], false, &pcm_buf[done * 8]);
+#endif
 	}
 
 	return payload_size * 8;
@@ -562,7 +566,11 @@ uint16 t_g729a_audio_decoder::conceal(int16 *pcm_buf, uint16 pcm_buf_size)
 {
 	assert(pcm_buf_size >= 80);
 
+#ifdef HAVE_BCG729_ANNEX_B
+	bcg729Decoder(_context, nullptr, 0, true, false, false, pcm_buf);
+#else
 	bcg729Decoder(_context, nullptr, true, pcm_buf);
+#endif
 	return 80;
 }
 

--- a/src/audio/audio_decoder.cpp
+++ b/src/audio/audio_decoder.cpp
@@ -536,14 +536,14 @@ t_g729a_audio_decoder::~t_g729a_audio_decoder()
 
 uint16 t_g729a_audio_decoder::get_ptime(uint16 payload_size) const
 {
-	return (payload_size * 8) / (audio_sample_rate(_codec) / 1000);
+	return ((payload_size / 10) * 80) / (audio_sample_rate(_codec) / 1000);
 }
 
 uint16 t_g729a_audio_decoder::decode(uint8 *payload, uint16 payload_size,
 		int16 *pcm_buf, uint16 pcm_buf_size)
 {
 	assert((payload_size % 10) == 0);
-	assert(pcm_buf_size >= payload_size*8);
+	assert(pcm_buf_size >= ((payload_size / 10) * 80));
 
 	uint8 frame_size = 10;
 	uint16 result_size = 0;

--- a/src/audio/audio_decoder.cpp
+++ b/src/audio/audio_decoder.cpp
@@ -545,16 +545,19 @@ uint16 t_g729a_audio_decoder::decode(uint8 *payload, uint16 payload_size,
 	assert((payload_size % 10) == 0);
 	assert(pcm_buf_size >= payload_size*8);
 
+	uint16 result_size = 0;
+
 	for (uint16 done = 0; done < payload_size; done += 10)
 	{
 #ifdef HAVE_BCG729_ANNEX_B
-		bcg729Decoder(_context, &payload[done], 0, false, false, false, &pcm_buf[done * 8]);
+		bcg729Decoder(_context, &payload[done], 0, false, false, false, &pcm_buf[result_size]);
 #else
-		bcg729Decoder(_context, &payload[done], false, &pcm_buf[done * 8]);
+		bcg729Decoder(_context, &payload[done], false, &pcm_buf[result_size]);
 #endif
+		result_size += 80;
 	}
 
-	return payload_size * 8;
+	return result_size;
 }
 
 bool t_g729a_audio_decoder::valid_payload_size(uint16 payload_size, uint16 sample_buf_size) const

--- a/src/audio/audio_decoder.cpp
+++ b/src/audio/audio_decoder.cpp
@@ -545,9 +545,10 @@ uint16 t_g729a_audio_decoder::decode(uint8 *payload, uint16 payload_size,
 	assert((payload_size % 10) == 0);
 	assert(pcm_buf_size >= payload_size*8);
 
+	uint8 frame_size = 10;
 	uint16 result_size = 0;
 
-	for (uint16 done = 0; done < payload_size; done += 10)
+	for (uint16 done = 0; done < payload_size; done += frame_size)
 	{
 #ifdef HAVE_BCG729_ANNEX_B
 		bcg729Decoder(_context, &payload[done], 0, false, false, false, &pcm_buf[result_size]);

--- a/src/audio/audio_decoder.cpp
+++ b/src/audio/audio_decoder.cpp
@@ -536,22 +536,31 @@ t_g729a_audio_decoder::~t_g729a_audio_decoder()
 
 uint16 t_g729a_audio_decoder::get_ptime(uint16 payload_size) const
 {
-	return ((payload_size / 10) * 80) / (audio_sample_rate(_codec) / 1000);
+	// Account for a possible 2-byte SID frame that will expand to 80
+	// samples juste like any other frame.  The (size+8)/10 expression,
+	// rounded down, results in the total number of frames, SID or not.
+	return (((payload_size + 8) / 10) * 80) / (audio_sample_rate(_codec) / 1000);
 }
 
 uint16 t_g729a_audio_decoder::decode(uint8 *payload, uint16 payload_size,
 		int16 *pcm_buf, uint16 pcm_buf_size)
 {
-	assert((payload_size % 10) == 0);
-	assert(pcm_buf_size >= ((payload_size / 10) * 80));
+	// Allow for a 2-byte SID frame at the end of the RTP packet
+	assert(((payload_size % 10) == 0) || ((payload_size % 10) == 2));
+	// See get_ptime() above for an explanation of this expression
+	assert(pcm_buf_size >= (((payload_size + 8) / 10) * 80));
 
 	uint8 frame_size = 10;
 	uint16 result_size = 0;
 
 	for (uint16 done = 0; done < payload_size; done += frame_size)
 	{
+		// RFC 3551 mandates that a SID frame be the last in the packet;
+		// its presence can thus be deduced from the payload size.
+		bool is_sid = ((payload_size - done) == 2);
+		frame_size = (is_sid ? 2 : 10);
 #ifdef HAVE_BCG729_ANNEX_B
-		bcg729Decoder(_context, &payload[done], 0, false, false, false, &pcm_buf[result_size]);
+		bcg729Decoder(_context, &payload[done], 0, false, is_sid, false, &pcm_buf[result_size]);
 #else
 		bcg729Decoder(_context, &payload[done], false, &pcm_buf[result_size]);
 #endif
@@ -563,7 +572,9 @@ uint16 t_g729a_audio_decoder::decode(uint8 *payload, uint16 payload_size,
 
 bool t_g729a_audio_decoder::valid_payload_size(uint16 payload_size, uint16 sample_buf_size) const
 {
-	return payload_size > 0 && (payload_size % 10) == 0;
+	// Allow for a 2-byte SID frame at the end of the RTP packet
+	return (payload_size > 0) &&
+		(((payload_size % 10) == 0) || ((payload_size % 10) == 2));
 }
 
 uint16 t_g729a_audio_decoder::conceal(int16 *pcm_buf, uint16 pcm_buf_size)

--- a/src/audio/audio_encoder.cpp
+++ b/src/audio/audio_encoder.cpp
@@ -433,7 +433,11 @@ uint16 t_g726_audio_encoder::encode(int16 *sample_buf, uint16 nsamples,
 t_g729a_audio_encoder::t_g729a_audio_encoder(uint16 payload_id, uint16 ptime, t_user *user_config)
 	: t_audio_encoder(payload_id, ptime, user_config)
 {
+#ifdef HAVE_BCG729_ANNEX_B
+	_context = initBcg729EncoderChannel(false);
+#else
 	_context = initBcg729EncoderChannel();
+#endif
 }
 
 t_g729a_audio_encoder::~t_g729a_audio_encoder()
@@ -451,7 +455,13 @@ uint16 t_g729a_audio_encoder::encode(int16 *sample_buf, uint16 nsamples,
 
 	for (uint16 done = 0; done < nsamples; done += 80)
 	{
+#ifdef HAVE_BCG729_ANNEX_B
+		uint8 frame_size = 10;
+		bcg729Encoder(_context, &sample_buf[done], &payload[done / 8], &frame_size);
+		assert(frame_size == 10);
+#else
 		bcg729Encoder(_context, &sample_buf[done], &payload[done / 8]);
+#endif
 	}
 
 	return nsamples / 8;

--- a/src/audio/audio_encoder.cpp
+++ b/src/audio/audio_encoder.cpp
@@ -449,7 +449,7 @@ uint16 t_g729a_audio_encoder::encode(int16 *sample_buf, uint16 nsamples,
 		uint8 *payload, uint16 payload_size, bool &silence)
 {
 	assert ((nsamples % 80) == 0);
-	assert (payload_size >= (nsamples/8));
+	assert (payload_size >= ((nsamples / 80) * 10));
 
 	silence = false;
 

--- a/src/audio/audio_encoder.cpp
+++ b/src/audio/audio_encoder.cpp
@@ -453,18 +453,21 @@ uint16 t_g729a_audio_encoder::encode(int16 *sample_buf, uint16 nsamples,
 
 	silence = false;
 
+	uint16 result_size = 0;
+
 	for (uint16 done = 0; done < nsamples; done += 80)
 	{
 #ifdef HAVE_BCG729_ANNEX_B
 		uint8 frame_size = 10;
-		bcg729Encoder(_context, &sample_buf[done], &payload[done / 8], &frame_size);
+		bcg729Encoder(_context, &sample_buf[done], &payload[result_size], &frame_size);
 		assert(frame_size == 10);
 #else
-		bcg729Encoder(_context, &sample_buf[done], &payload[done / 8]);
+		bcg729Encoder(_context, &sample_buf[done], &payload[result_size]);
 #endif
+		result_size += 10;
 	}
 
-	return nsamples / 8;
+	return result_size;
 }
 
 #endif

--- a/src/audio/audio_encoder.cpp
+++ b/src/audio/audio_encoder.cpp
@@ -453,18 +453,17 @@ uint16 t_g729a_audio_encoder::encode(int16 *sample_buf, uint16 nsamples,
 
 	silence = false;
 
+	uint8 frame_size = 10;
 	uint16 result_size = 0;
 
 	for (uint16 done = 0; done < nsamples; done += 80)
 	{
 #ifdef HAVE_BCG729_ANNEX_B
-		uint8 frame_size = 10;
 		bcg729Encoder(_context, &sample_buf[done], &payload[result_size], &frame_size);
-		assert(frame_size == 10);
 #else
 		bcg729Encoder(_context, &sample_buf[done], &payload[result_size]);
 #endif
-		result_size += 10;
+		result_size += frame_size;
 	}
 
 	return result_size;

--- a/src/audio/audio_encoder.cpp
+++ b/src/audio/audio_encoder.cpp
@@ -451,8 +451,6 @@ uint16 t_g729a_audio_encoder::encode(int16 *sample_buf, uint16 nsamples,
 	assert ((nsamples % 80) == 0);
 	assert (payload_size >= ((nsamples / 80) * 10));
 
-	silence = false;
-
 	uint8 frame_size = 10;
 	uint16 result_size = 0;
 
@@ -465,6 +463,8 @@ uint16 t_g729a_audio_encoder::encode(int16 *sample_buf, uint16 nsamples,
 #endif
 		result_size += frame_size;
 	}
+
+	silence = false;
 
 	return result_size;
 }

--- a/src/audio/audio_encoder.cpp
+++ b/src/audio/audio_encoder.cpp
@@ -434,6 +434,7 @@ t_g729a_audio_encoder::t_g729a_audio_encoder(uint16 payload_id, uint16 ptime, t_
 	: t_audio_encoder(payload_id, ptime, user_config)
 {
 #ifdef HAVE_BCG729_ANNEX_B
+	// Disable G.729B features for the time being
 	_context = initBcg729EncoderChannel(false);
 #else
 	_context = initBcg729EncoderChannel();
@@ -454,6 +455,9 @@ uint16 t_g729a_audio_encoder::encode(int16 *sample_buf, uint16 nsamples,
 	uint8 frame_size = 10;
 	uint16 result_size = 0;
 
+	// G.729B TODO: RFC 3551 mandates that a SID frame be the last in the
+	// packet; this could require us to only encode a portion of the
+	// samples, which the current interface does not allow for.
 	for (uint16 done = 0; done < nsamples; done += 80)
 	{
 #ifdef HAVE_BCG729_ANNEX_B
@@ -464,8 +468,13 @@ uint16 t_g729a_audio_encoder::encode(int16 *sample_buf, uint16 nsamples,
 		result_size += frame_size;
 	}
 
-	silence = false;
+	silence = (result_size == 0);
 
+	// G.729B TODO: In the event that the encoding only resulted in
+	// untransmitted frames, we would return 0 bytes; the caller should be
+	// ready for that outcome.  (At the moment, when sending a keepalive
+	// packet, it would call putData() with len = 0, which is interpreted as
+	// "a default by payload type".)
 	return result_size;
 }
 

--- a/twinkle_config.h.in
+++ b/twinkle_config.h.in
@@ -3,6 +3,7 @@
 #cmakedefine HAVE_ILBC
 #cmakedefine HAVE_ZRTP
 #cmakedefine HAVE_BCG729
+#cmakedefine HAVE_BCG729_ANNEX_B
 #cmakedefine HAVE_GSM
 
 #cmakedefine HAVE_UNISTD_H


### PR DESCRIPTION
As bcg729 now supports G.729 Annex B (since 1.0.2), it should be possible (once #104 has been merged) for Twinkle to do the same, at least in theory.

This PR lays most of the groundwork necessary to handle SID frames and DTX properly.  (VAD is obviously none of our concern, and CNG is done automatically through the same process as frame erasure concealment.)

To quote the state of affairs from the last commit:

- Everything should be ready on the decoder side: SID frames (notwithstanding RFC 3389) will be decoded as expected, and untransmitted frames will be treated as erased frames, where `conceal()` will end up generating the comfort noise (this is all done transparently by bcg729).
- On the encoder side, as indicated by the code comments, two issues remain: one regarding SID frames (if they do not happen to be at the end of the payload), and one with an empty payload of only untransmitted frames (if it ends up being transmitted nonetheless as a NAT keepalive).

I think I could tackle the second issue by myself, but the first one is beyond my abilities.  (Can we afford to mercilessly drop the other samples after a SID frame?)

Some additional points:

- Despite what it may look like, I actually have no experience or expertise in any of this stuff.  (I'm merely a fast learner, that's all.)  Therefore, it's quite possible that I got a few (or many) things wrong.  Please let me know of any mistake I may have made.

- It goes without saying that none of this has ever been tested, aside from confirming that "yup, it does compile just fine".  :smile:  Although the Annex B aspect isn't functional yet, it would be nice to confirm that I did not wreck the common G.729 code by mistake.  If someone could check and make sure, this would be most welcome!

- The first two commits are merely a copy of #152, on which this PR depends.

- The other commits prior to the last one may appear needlessly trivial; their role is merely to lessen the size and complexity of the last commit.  I tried to make the job of whoever is going to review this PR as easy and painless as I could manage.

---
(Filing this as a draft PR, until #104 is merged.)