### PR TITLE
Simple fixes for two deadlocks

### DIFF
--- a/src/phone.cpp
+++ b/src/phone.cpp
@@ -279,8 +279,6 @@ void t_phone::end_call(void) {
 			move_line_to_background(lineno1);
 			move_line_to_background(lineno2);
 		} else {
-			t_rwmutex_reader x(lines_mtx);
-
 			// Hangup the active line, and make the next
 			// line active.
 			int l = active_line;

--- a/src/phone.h
+++ b/src/phone.h
@@ -130,7 +130,7 @@ private:
 	bool			is_3way;	// indicates an acitive 3-way
 	t_line			*line1_3way;	// first line in 3-way conf
 	t_line			*line2_3way;	// second line in 3-way conf
-	mutable t_mutex mutex_3way;
+	mutable t_recursive_mutex mutex_3way;
 	
 	// Call transfer data. When a REFER comes in, the user has
 	// to give permission before the triggered INVITE can be sent.


### PR DESCRIPTION
These two commits deal with the easy parts of #165, fixing "mutex_3way: Recursive locking" as well as part of "Ending a 3-way call with hangup_both_3way disabled".