### PR TITLE
Introduce read-write-update locks and guards to prevent deadlocks

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,7 @@ add_executable(twinkle-console
 )
 
 set(twinkle_LIBS
+	-latomic
 	-lpthread
 	-lresolv
 	${LibMagic_LIBRARY}

--- a/src/phone.cpp
+++ b/src/phone.cpp
@@ -1704,7 +1704,7 @@ void t_phone::recvd_notify(t_request *r, t_tid tid) {
 	}
 
 	// REFER notification
-	t_rwmutex_reader x(lines_mtx);
+	t_rwmutex_future_writer x(lines_mtx);
 	for (unsigned short i = 0; i < lines.size(); i++) {
 		if (lines[i]->match(r)) {
 			lines[i]->recvd_notify(r, tid);

--- a/src/phone.cpp
+++ b/src/phone.cpp
@@ -339,7 +339,7 @@ void t_phone::refer(const t_url &uri, const string &display) {
 
 void t_phone::refer(unsigned short lineno_from, unsigned short lineno_to) 
 {
-	t_rwmutex_reader x(lines_mtx);
+	t_rwmutex_future_writer x(lines_mtx);
 
 	// The nicest transfer is an attended transfer. An attended transfer
 	// is only possible of the transfer target supports the 'replaces'

--- a/src/phone.cpp
+++ b/src/phone.cpp
@@ -279,8 +279,6 @@ void t_phone::end_call(void) {
 			move_line_to_background(lineno1);
 			move_line_to_background(lineno2);
 		} else {
-			t_rwmutex_reader x(lines_mtx);
-
 			// Hangup the active line, and make the next
 			// line active.
 			int l = active_line;

--- a/src/phone.cpp
+++ b/src/phone.cpp
@@ -905,7 +905,7 @@ void t_phone::post_process_response(t_response *r, t_tuid tuid, t_tid tid) {
 }
 
 void t_phone::recvd_invite(t_request *r, t_tid tid) {
-	t_rwmutex_reader x(lines_mtx);
+	t_rwmutex_future_writer x(lines_mtx);
 
 	// Check if this INVITE is a retransmission.
 	// Once the TU sent a 2XX repsonse on an INVITE it has to deal

--- a/src/phone.cpp
+++ b/src/phone.cpp
@@ -1871,7 +1871,7 @@ void t_phone::recvd_refer_permission(bool permission) {
 	t_phone_user *pu = incoming_refer_data->get_phone_user();
 	t_user *user_config = pu->get_user_profile();
 			
-	t_rwmutex_reader x(lines_mtx);
+	t_rwmutex_future_writer x(lines_mtx);
 	lines[i]->recvd_refer_permission(permission, r);
 	
 	if (!permission) {

--- a/src/phone.h
+++ b/src/phone.h
@@ -130,7 +130,7 @@ private:
 	bool			is_3way;	// indicates an acitive 3-way
 	t_line			*line1_3way;	// first line in 3-way conf
 	t_line			*line2_3way;	// second line in 3-way conf
-	mutable t_mutex mutex_3way;
+	mutable t_recursive_mutex mutex_3way;
 	
 	// Call transfer data. When a REFER comes in, the user has
 	// to give permission before the triggered INVITE can be sent.

--- a/src/threads/mutex.cpp
+++ b/src/threads/mutex.cpp
@@ -129,7 +129,13 @@ void t_rwmutex::unlock()
 // t_rwmutex_guard
 ///////////////////////////
 
-t_rwmutex_reader::t_rwmutex_reader(t_rwmutex& mutex) : _mutex(mutex)
+t_rwmutex_guard::t_rwmutex_guard(t_rwmutex& mutex) :
+	_mutex(mutex)
+{
+}
+
+t_rwmutex_reader::t_rwmutex_reader(t_rwmutex& mutex) :
+	t_rwmutex_guard(mutex)
 {
 	// std::cout << "mtx rd lock " << (void*)&_mutex << std::endl;
 	_mutex.lockRead();
@@ -141,7 +147,8 @@ t_rwmutex_reader::~t_rwmutex_reader()
 	_mutex.unlock();
 }
 
-t_rwmutex_writer::t_rwmutex_writer(t_rwmutex& mutex) : _mutex(mutex)
+t_rwmutex_writer::t_rwmutex_writer(t_rwmutex& mutex) :
+	t_rwmutex_guard(mutex)
 {
 	// std::cout << "mtx wr lock " << (void*)&_mutex << std::endl;
 	_mutex.lockWrite();

--- a/src/threads/mutex.cpp
+++ b/src/threads/mutex.cpp
@@ -124,3 +124,31 @@ void t_rwmutex::unlock()
 {
 	pthread_rwlock_unlock(&_lock);
 }
+
+///////////////////////////
+// t_rwmutex_guard
+///////////////////////////
+
+t_rwmutex_reader::t_rwmutex_reader(t_rwmutex& mutex) : _mutex(mutex)
+{
+	// std::cout << "mtx rd lock " << (void*)&_mutex << std::endl;
+	_mutex.lockRead();
+}
+
+t_rwmutex_reader::~t_rwmutex_reader()
+{
+	// std::cout << "mtx rd unlock " << (void*)&_mutex << std::endl;
+	_mutex.unlock();
+}
+
+t_rwmutex_writer::t_rwmutex_writer(t_rwmutex& mutex) : _mutex(mutex)
+{
+	// std::cout << "mtx wr lock " << (void*)&_mutex << std::endl;
+	_mutex.lockWrite();
+}
+
+t_rwmutex_writer::~t_rwmutex_writer()
+{
+	// std::cout << "mtx wr unlock " << (void*)&_mutex << std::endl;
+	_mutex.unlock();
+}

--- a/src/threads/mutex.h
+++ b/src/threads/mutex.h
@@ -95,17 +95,22 @@ public:
 	void unlock();
 };
 
-class t_rwmutex_reader {
-private:
+// Base (abstract) class
+class t_rwmutex_guard {
+protected:
 	t_rwmutex& _mutex;
+
+	// A protected constructor to keep this class abstract
+	t_rwmutex_guard(t_rwmutex& mutex);
+};
+
+class t_rwmutex_reader : public t_rwmutex_guard {
 public:
 	t_rwmutex_reader(t_rwmutex& mutex);
 	~t_rwmutex_reader();
 };
 
-class t_rwmutex_writer {
-private:
-	t_rwmutex& _mutex;
+class t_rwmutex_writer : public t_rwmutex_guard {
 public:
 	t_rwmutex_writer(t_rwmutex& mutex);
 	~t_rwmutex_writer();

--- a/src/threads/mutex.h
+++ b/src/threads/mutex.h
@@ -21,6 +21,7 @@
 #include <errno.h>
 #include <pthread.h>
 // #include <iostream>
+#include <atomic>
 
 /**
  * @file
@@ -83,33 +84,100 @@ public:
 	~t_mutex_guard();
 };
 
+
+// Read-write-update lock
+//
+// Read-write lock with an additional "update" type of lock, which can later
+// be upgraded to "write" (and downgraded back to "update" again).  An update
+// lock can co-exist with other read locks, but only one update lock can be
+// held at any time, representing ownership of upgrade rights.
+//
+// See https://stackoverflow.com/a/18785300 for details and further references.
+//
+// Note that our version is rather simplistic, and does not allow downgrading
+// from update/write to read.
+
+// A cheap substitute for std::optional<pthread_t>, only available in C++14.
+// Unfortunately, POSIX.1-2004 no longer requires pthread_t to be an arithmetic
+// type, so we can't simply use 0 as an (unofficial) invalid thread ID.
+struct optional_pthread_t {
+	bool has_value;
+	pthread_t value;
+};
+
 class t_rwmutex {
 protected:
+	// Standard read-write lock
 	pthread_rwlock_t _lock;
+	// Mutex for upgrade ownership
+	t_mutex _up_mutex;
+	// Thread ID that currently owns the _up_mutex lock, if any
+	std::atomic<optional_pthread_t> _up_mutex_thread;
+
+	// Get/release upgrade ownership
+	void getUpgradeOwnership();
+	void releaseUpgradeOwnership();
+
+	// Internal methods to manipulate _lock directly
+	void _lockRead();
+	void _lockWrite();
+	void _unlock();
 public:
 	t_rwmutex();
 	~t_rwmutex();
 
+	// Returns true if the calling thread currently owns the _up_mutex lock
+	bool isUpgradeOwnershipOurs() const;
+
+	// The usual methods for obtaining/releasing locks
 	void lockRead();
+	void lockUpdate();
 	void lockWrite();
 	void unlock();
+
+	// Upgrade an update lock to a write lock, or downgrade in the
+	// opposite direction.  Note that this does not count as an additional
+	// lock, so only one unlock() call will be needed at the end.
+	void upgradeLock();
+	void downgradeLock();
 };
+
+
+// Equivalent of t_mutex_guard for t_rwmutex
+//
+// These can be nested as indicated below.  Note that nesting a weaker guard
+// will not downgrade the lock; for example, a Reader guard within a Writer
+// guard will maintain the write lock.
 
 // Base (abstract) class
 class t_rwmutex_guard {
 protected:
+	// The lock itself
 	t_rwmutex& _mutex;
+
+	// Whether or not we had upgrade ownership beforehand, indicating that
+	// we are nested within the scope of a writer/future_writer guard
+	bool _previously_owned_upgrade;
 
 	// A protected constructor to keep this class abstract
 	t_rwmutex_guard(t_rwmutex& mutex);
 };
 
+// Reader: Can be nested within the scope of any guard
 class t_rwmutex_reader : public t_rwmutex_guard {
 public:
 	t_rwmutex_reader(t_rwmutex& mutex);
 	~t_rwmutex_reader();
 };
 
+// Future writer: Can be nested within the scope of a future_writer guard
+class t_rwmutex_future_writer : public t_rwmutex_guard {
+public:
+	t_rwmutex_future_writer(t_rwmutex& mutex);
+	~t_rwmutex_future_writer();
+};
+
+// Writer: Can be nested within the scope of a future_writer guard
 class t_rwmutex_writer : public t_rwmutex_guard {
 public:
 	t_rwmutex_writer(t_rwmutex& mutex);

--- a/src/threads/mutex.h
+++ b/src/threads/mutex.h
@@ -99,28 +99,16 @@ class t_rwmutex_reader {
 private:
 	t_rwmutex& _mutex;
 public:
-	t_rwmutex_reader(t_rwmutex& mutex) : _mutex(mutex) {
-		// std::cout << "mtx rd lock " << (void*)&_mutex << std::endl;
-		_mutex.lockRead();
-	}
-	~t_rwmutex_reader() {
-		// std::cout << "mtx rd unlock " << (void*)&_mutex << std::endl;
-		_mutex.unlock();
-	}
+	t_rwmutex_reader(t_rwmutex& mutex);
+	~t_rwmutex_reader();
 };
 
 class t_rwmutex_writer {
 private:
 	t_rwmutex& _mutex;
 public:
-	t_rwmutex_writer(t_rwmutex& mutex) : _mutex(mutex) {
-		// std::cout << "mtx wr lock " << (void*)&_mutex << std::endl;
-		_mutex.lockWrite();
-	}
-	~t_rwmutex_writer() {
-		// std::cout << "mtx wr unlock " << (void*)&_mutex << std::endl;
-		_mutex.unlock();
-	}
+	t_rwmutex_writer(t_rwmutex& mutex);
+	~t_rwmutex_writer();
 };
 
 


### PR DESCRIPTION
This converts `t_rwmutex` and `t_rwmutex_guard` into a read-write-update[*]
lock and guard, in an attempt to circumvent the various deadlocks that
were introduced with the addition of `lines_mtx` in 38bb6b7.

[*] For more details, see https://stackoverflow.com/a/18785300 and
http://lkml.iu.edu/hypermail/linux/kernel/0004.3/0117.html.

Note that this is not a real fix; this would require analyzing and
refactoring `phone.cpp`, which is well beyond my abilities.  This is at
best a workaround that appears to conveniently dodge all the deadlocks
I've encountered so far.

(It would have been more proper to introduce a separate class for this
purpose, but this would have required modifying over 80 lines just to
change one type for another.  As `phone_users_mtx` is the only other
instance of this class, the impact of subverting `t_rwmutex` directly is
minimal.)

Closes #165