### PR TITLE
Add -DDEBUG to non-release builds, to prevent uCommon from adding NDEBUG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,14 @@
 project(twinkle)
 
-cmake_minimum_required(VERSION 2.6.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.10 FATAL_ERROR)
 
 set(PRODUCT_VERSION "1.10.2")
 set(PRODUCT_DATE    "February 14, 2018")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+# Add -DDEBUG for non-release builds, or uCommon will unilaterally define NDEBUG
+# (https://lists.gnu.org/archive/html/bug-commoncpp/2019-12/msg00000.html)
+set_directory_properties(PROPERTIES
+	COMPILE_DEFINITIONS $<$<OR:$<CONFIG:>,$<CONFIG:Debug>>:DEBUG>)
 
 OPTION(WITH_ZRTP		"Enable ZRTP encrypted calls" OFF)
 OPTION(WITH_SPEEX		"Enable the Speex codec" OFF)


### PR DESCRIPTION
Including <ucommon/ucommon.h> will (as of uCommon 7.0.0) unilaterally
define NDEBUG, and thus compile away any assert(), unless DEBUG has been
previously defined.[1]  Until this is fixed, the easiest way around this
is simply to automatically define DEBUG for non-release builds.

Note that there are a few other header files that check for the presence
of DEBUG[2], but the net effect appears to be non-significant.  (It *is*
a debug build, after all!)

 [1] https://lists.gnu.org/archive/html/bug-commoncpp/2019-12/msg00000.html

 [2] - libxml2/libxml/xmlmemory.h
     - X11/Xthreads.h
     - X11/extensions/lbxproto.h
     - FLAC/assert.h