### PR TITLE
Switch Travis CI distribution to bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,19 @@
 language: cpp
-dist: trusty
+dist: bionic
 sudo: required
 
 env:
   global:
-    - FLAGS="-DWITH_QT5=ON -DWITH_ALSA=ON -DWITH_GSM=ON -DWITH_SPEEX=ON -DWITH_ZRTP=ON"
+    - FLAGS="-DWITH_QT5=ON -DWITH_ALSA=ON -DWITH_GSM=ON -DWITH_SPEEX=ON -DWITH_ZRTP=OFF"
     # (qttools5-dev-tools is explicitly included because of Debian bug #835295)
-    - PACKAGES="libasound2-dev libgsm1-dev libspeex-dev libspeexdsp-dev libzrtpcpp-dev qtdeclarative5-dev qttools5-dev qttools5-dev-tools"
+    - PACKAGES="libasound2-dev libgsm1-dev libspeex-dev libspeexdsp-dev qtdeclarative5-dev qttools5-dev qttools5-dev-tools"
   matrix:
     # Test various compiler versions
-    - PACKAGES_ADD="g++-4.9" MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
     - PACKAGES_ADD="g++-5"   MATRIX_EVAL="CC=gcc-5   && CXX=g++-5"
     - PACKAGES_ADD="g++-6"   MATRIX_EVAL="CC=gcc-6   && CXX=g++-6"
-    # The version of uCommon available on trusty (6.0.7) will cause a build
-    # failure when compiling with GCC 7 or Clang.
-    #- PACKAGES_ADD="g++-7"   MATRIX_EVAL="CC=gcc-7   && CXX=g++-7"
+    - PACKAGES_ADD="g++-7"   MATRIX_EVAL="CC=gcc-7   && CXX=g++-7"
+    - PACKAGES_ADD="g++-8"   MATRIX_EVAL="CC=gcc-8   && CXX=g++-8"
+    - PACKAGES_ADD="g++-9"   MATRIX_EVAL="CC=gcc-9   && CXX=g++-9"
     # Test with all options disabled
     - FLAGS="-DWITH_QT5=OFF -DWITH_ALSA=OFF -DWITH_GSM=OFF -DWITH_SPEEX=OFF -DWITH_ZRTP=OFF" PACKAGES=""
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,15 @@ env:
     - PACKAGES="libasound2-dev libgsm1-dev libspeex-dev libspeexdsp-dev qtdeclarative5-dev qttools5-dev qttools5-dev-tools"
   matrix:
     # Test various compiler versions
-    - PACKAGES_ADD="g++-5"   MATRIX_EVAL="CC=gcc-5   && CXX=g++-5"
-    - PACKAGES_ADD="g++-6"   MATRIX_EVAL="CC=gcc-6   && CXX=g++-6"
-    - PACKAGES_ADD="g++-7"   MATRIX_EVAL="CC=gcc-7   && CXX=g++-7"
-    - PACKAGES_ADD="g++-8"   MATRIX_EVAL="CC=gcc-8   && CXX=g++-8"
-    - PACKAGES_ADD="g++-9"   MATRIX_EVAL="CC=gcc-9   && CXX=g++-9"
+    - PACKAGES_ADD="g++-5"     MATRIX_EVAL="CC=gcc-5     && CXX=g++-5"
+    - PACKAGES_ADD="g++-6"     MATRIX_EVAL="CC=gcc-6     && CXX=g++-6"
+    - PACKAGES_ADD="g++-7"     MATRIX_EVAL="CC=gcc-7     && CXX=g++-7"
+    - PACKAGES_ADD="g++-8"     MATRIX_EVAL="CC=gcc-8     && CXX=g++-8"
+    - PACKAGES_ADD="g++-9"     MATRIX_EVAL="CC=gcc-9     && CXX=g++-9"
+    - PACKAGES_ADD="clang-3.9" MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
+    - PACKAGES_ADD="clang-4.0" MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+    - PACKAGES_ADD="clang-5.0" MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+    - PACKAGES_ADD="clang-6.0" MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
     # Test with all options disabled
     - FLAGS="-DWITH_QT5=OFF -DWITH_ALSA=OFF -DWITH_GSM=OFF -DWITH_SPEEX=OFF -DWITH_ZRTP=OFF" PACKAGES=""
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
     - PACKAGES_ADD="clang-4.0" MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
     - PACKAGES_ADD="clang-5.0" MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
     - PACKAGES_ADD="clang-6.0" MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+    - PACKAGES_ADD="clang-7"   MATRIX_EVAL="CC=clang-7   && CXX=clang++-7"
+    - PACKAGES_ADD="clang-8"   MATRIX_EVAL="CC=clang-8   && CXX=clang++-8"
     # Test with all options disabled
     - FLAGS="-DWITH_QT5=OFF -DWITH_ALSA=OFF -DWITH_GSM=OFF -DWITH_SPEEX=OFF -DWITH_ZRTP=OFF" PACKAGES=""
 


### PR DESCRIPTION
Older versions of ccrtp under trusty/xenial do not compile with g++ 7+,
so moving on to bionic will finally allow us to test modern compilers.
(Ironically, current ccrtp will no longer compile with g++ 4.9.)

Note that libzrtpcpp is no longer available on bionic, so it was
disabled from the tests.