### PR TITLE
let gui set MAX_PTIME cutoff 80ms

### DIFF
--- a/src/gui/userprofileform.ui
+++ b/src/gui/userprofileform.ui
@@ -823,7 +823,7 @@ This field is mandatory.</string>
                 <number>10</number>
                </property>
                <property name="maximum">
-                <number>50</number>
+                <number>80</number>
                </property>
                <property name="singleStep">
                 <number>10</number>


### PR DESCRIPTION
match with 

> higher defined
> https://github.com/LubosD/twinkle/blob/da70392f6959e16243272e8abccebd95f8bfaf47/src/audio/audio_codecs.h#L50

fix: gui does not let set MAX_PTIME cutoff >50 https://github.com/LubosD/twinkle/issues/159

