### PR TITLE
Update sources to compile against the latest version of the bcg729 codec library

### DIFF
--- a/src/audio/audio_decoder.cpp
+++ b/src/audio/audio_decoder.cpp
@@ -547,7 +547,7 @@ uint16 t_g729a_audio_decoder::decode(uint8 *payload, uint16 payload_size,
 
 	for (uint16 done = 0; done < payload_size; done += 10)
 	{
-		bcg729Decoder(_context, &payload[done], false, &pcm_buf[done * 8]);
+		bcg729Decoder(_context, &payload[done], 10, false, false, false, &pcm_buf[done * 8]);
 	}
 
 	return payload_size * 8;
@@ -562,7 +562,7 @@ uint16 t_g729a_audio_decoder::conceal(int16 *pcm_buf, uint16 pcm_buf_size)
 {
 	assert(pcm_buf_size >= 80);
 
-	bcg729Decoder(_context, nullptr, true, pcm_buf);
+	bcg729Decoder(_context, nullptr, 0, true, false, false, pcm_buf);
 	return 80;
 }
 

--- a/src/audio/audio_encoder.cpp
+++ b/src/audio/audio_encoder.cpp
@@ -433,7 +433,8 @@ uint16 t_g726_audio_encoder::encode(int16 *sample_buf, uint16 nsamples,
 t_g729a_audio_encoder::t_g729a_audio_encoder(uint16 payload_id, uint16 ptime, t_user *user_config)
 	: t_audio_encoder(payload_id, ptime, user_config)
 {
-	_context = initBcg729EncoderChannel();
+	static const bool ENABLE_VAD = false;
+	_context = initBcg729EncoderChannel(ENABLE_VAD);
 }
 
 t_g729a_audio_encoder::~t_g729a_audio_encoder()
@@ -449,9 +450,11 @@ uint16 t_g729a_audio_encoder::encode(int16 *sample_buf, uint16 nsamples,
 
 	silence = false;
 
+	uint8_t bitStreamLength;
 	for (uint16 done = 0; done < nsamples; done += 80)
 	{
-		bcg729Encoder(_context, &sample_buf[done], &payload[done / 8]);
+		bcg729Encoder(_context, &sample_buf[done], &payload[done / 8], &bitStreamLength);
+		assert(bitStreamLength == 10);
 	}
 
 	return nsamples / 8;


### PR DESCRIPTION
There have been some compatibility-breaking API changes in the bcg729 library
already as early as 2015. Some function signatures have been changed and new function
parameters were added to support Voice Activity Detection (VAD). Even though these
changes already date back to 2015, twinkle has so far not been updated. This is why
twinkle cannot be compiled against new versions of bcg729 anymore.

This commit fixes these issues and changes the source code to match the new
function signatures. I verified that everything works using a test call with the
G729 codec.