### PR TITLE
Use the first payload type number for each codec in the SDP answer

### DIFF
--- a/src/session.cpp
+++ b/src/session.cpp
@@ -44,7 +44,10 @@ void t_session::set_recvd_codecs(t_sdp *sdp) {
 		t_audio_codec ac = sdp->get_codec(SDP_AUDIO, *i);
 		if (ac > CODEC_UNSUPPORTED) {
 			recvd_codecs.push_back(ac);
-			send_ac2payload[ac] = *i;
+			// Don't overwrite any previous mapping for this codec
+			if (!send_ac2payload.count(ac)) {
+				send_ac2payload[ac] = *i;
+			}
 			send_payload2ac[*i] = ac;
 		}
 	}


### PR DESCRIPTION
It is possible for the SDP offer to feature more than one payload type
number (either static or dynamic) that refer to the same codec.  For
example, a peer that supports ITU-T V.152 may use two payload types,
with one of them marked for voice-band data use:

    m=audio 3456 RTP/AVP 0 98
    a=rtpmap:0 PCMU/8000
    a=rtpmap:98 PCMU/8000
    a=gpmd:98 vbd=yes

Ideally, Twinkle should use the number that was listed first in the
media formats list when building the SDP answer.

Closes #184