### PR TITLE
Set the windowTitle property of callToolbar

### DIFF
--- a/src/gui/mphoneform.ui
+++ b/src/gui/mphoneform.ui
@@ -1015,6 +1015,9 @@
    </layout>
   </widget>
   <widget class="QToolBar" name="callToolbar">
+   <property name="windowTitle">
+    <string>Main Toolbar</string>
+   </property>
    <property name="toolButtonStyle">
     <enum>Qt::ToolButtonTextUnderIcon</enum>
    </property>


### PR DESCRIPTION
The window title of a toolbar is displayed in the default context menu
of the main window.

Closes #195