### PR TITLE
Fix overlap of two settings in syssettingsform.ui

### DIFF
--- a/src/gui/syssettingsform.ui
+++ b/src/gui/syssettingsform.ui
@@ -955,7 +955,7 @@ If before answering a call, the microphone or speaker appears to be invalid, a w
          </item>
         </layout>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <layout class="QHBoxLayout">
          <item>
           <widget class="QLabel" name="browserTextLabel">


### PR DESCRIPTION
The merging of 1e9f091 (#123) and f3d6f33 (#126) resulted in a
positional conflict in syssettingsform.ui.