### PR TITLE
Fix typo in German language file

### DIFF
--- a/src/gui/lang/twinkle_de.ts
+++ b/src/gui/lang/twinkle_de.ts
@@ -1010,7 +1010,7 @@ Es bietet sich an, hier Ihre SIP-Adresse als Name zu verwenden, also &lt;b&gt;me
     </message>
     <message>
         <source>Time</source>
-        <translation>Uhreit</translation>
+        <translation>Uhrzeit</translation>
     </message>
     <message>
         <source>In/Out</source>


### PR DESCRIPTION
Missing letter inside the word "Uhrzeit"