### PR TITLE
Suppress deprecation warnings from Qt

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,5 +1,9 @@
 project(twinkle-gui)
 
+# Suppress deprecation warnings from Qt, as they often would require breaking
+# backwards compatibility.
+add_definitions(-DQT_NO_DEPRECATED_WARNINGS)
+
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
Starting from Qt 5.13, QT_DEPRECATED_WARNINGS is now enabled by default.
Unfortunately, methods are often deprecated not long after a suitable
alternative is available, meaning that getting rid of these warnings
would require breaking backwards compatibility (or sprinkling QT_VERSION
checks everywhere).

(See QList::fromStdList() as an example, which was marked as deprecated
merely a month after range constructors were made available.)

This reverts things to how they were before.  Getting rid of these
warnings will probably be part of the job when porting to Qt 6.