### PR TITLE
Helper script: twinkle-call calls a number. This script is useful whe…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,9 @@ configure_file(twinkle.desktop.in twinkle.desktop)
 
 include_directories("${CMAKE_BINARY_DIR}")
 
+install(FILES "bin/twinkle-call"
+	PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+	DESTINATION "bin")
 install(FILES
 	${CMAKE_CURRENT_SOURCE_DIR}/data/providers.csv
 	${CMAKE_CURRENT_SOURCE_DIR}/data/ringtone.wav

--- a/bin/twinkle-call
+++ b/bin/twinkle-call
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+twinkle --call "`echo "$1" | sed s/tel://`"


### PR DESCRIPTION
This script is useful when connecting your browsers tel: url to twinkle

Tested with firefox web browser; the browser is now able to redirect tel: urls to twinkle