### PR TITLE
Return 408 when no answer

### DIFF
--- a/src/line.cpp
+++ b/src/line.cpp
@@ -1788,7 +1788,7 @@ void t_line::timeout(t_line_timer timer, t_object_id did) {
 				active_dialog->redirect(cf_dest,
 					R_302_MOVED_TEMPORARILY);
 			} else {
-				active_dialog->reject(R_480_TEMP_NOT_AVAILABLE,
+				active_dialog->reject(R_408_REQUEST_TIMEOUT,
 					REASON_480_NO_ANSWER);
 			}
 			


### PR DESCRIPTION
From RFC 3261:
```
21.4.9 408 Request Timeout

   The server could not produce a response within a suitable amount of
   time, for example, if it could not determine the location of the user
   in time.  The client MAY repeat the request without modifications at
   any later time.
```

I think here by "server" it refers to a "user agent server" since 4xx are client-related codes.

Thank you,
Stefan