### PR TITLE
changed references to http(s)://twinklephone.com

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,4 +35,4 @@ Russian Michail Chodorenko
 Swedish Daniel Nylander
 
 Michel de Boer
-www.twinklephone.com
+https://mfnboer.home.xs4all.nl/twinkle/

--- a/src/gui/lang/twinkle_de.ts
+++ b/src/gui/lang/twinkle_de.ts
@@ -5620,7 +5620,7 @@ The values of all SIP headers in the incoming INVITE message are passed in envir
 TWINKLE_TRIGGER=in_call. SIPREQUEST_METHOD=INVITE. The request-URI of the INVITE will be passed in &lt;b&gt;SIPREQUEST_URI&lt;/b&gt;. The name of the user profile will be passed in &lt;b&gt;TWINKLE_USER_PROFILE&lt;/b&gt;.</source>
         <translation>&lt;p&gt;
 Dieses Script wird gerufen, wenn ein INVITE (Anruf) ankommt. &lt;br&gt;
-Bitte lesen Sie im Handbuch unter &quot;/usr/share/doc/packages/twinkle/...&quot; oder &quot;http://twinklephone.com&quot;  die ausführliche Beschreibung!
+Bitte lesen Sie im Handbuch unter &quot;/usr/share/doc/packages/twinkle/...&quot; oder &quot;https://mfnboer.home.xs4all.nl/twinkle/&quot; die ausführliche Beschreibung!
 &lt;/p&gt;
 &lt;h3&gt;Rückgabewerte&lt;/h3&gt; -   print nach STDOUT (z.B. `echo &quot;action=dnd&quot;`), ein Wert pro Zeile: &lt;br&gt;
 &lt;tt&gt;action=[ continue | reject | dnd | redirect | autoanswer ]&lt;br&gt;&lt;/tt&gt;

--- a/src/gui/mphoneform.cpp
+++ b/src/gui/mphoneform.cpp
@@ -2297,7 +2297,7 @@ void MphoneForm::aboutQt()
 
 void MphoneForm::manual()
 {
-	((t_gui *)ui)->open_url_in_browser("https://web.archive.org/web/20180217123024/http://www.twinklephone.com/");
+	((t_gui *)ui)->open_url_in_browser("https://mfnboer.home.xs4all.nl/twinkle/");
 }
 
 void MphoneForm::editUserProfile()

--- a/twinkle.spec.in
+++ b/twinkle.spec.in
@@ -10,7 +10,7 @@ BuildArch:	i586
 #BuildArch:	x86_64
 BuildRoot:	%{_tmppath}/making_of_%{name}_%{version}
 Packager:
-URL:		http://www.twinklephone.com
+URL:		https://mfnboer.home.xs4all.nl/twinkle/
 Requires:	alsa
 Requires:	ucommon
 Requires:	ccrtp >= 1.6.0


### PR DESCRIPTION
changed references to http(s)://twinklephone.com to https://mfnboer.home.xs4all.nl/twinkle/

The domain is not related to Twinkle any more.