### PR TITLE
Add a `-t` flag to the `hold` CLI command to toggle call on-hold status

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -284,9 +284,10 @@ void t_gui::do_bye(void) {
 	QMetaObject::invokeMethod(this, "gui_do_bye");
 }
 
-void t_gui::do_hold(void) {
+void t_gui::do_hold(bool toggle) {
 
-	QMetaObject::invokeMethod(this, "gui_do_hold");
+	QMetaObject::invokeMethod(this, "gui_do_hold",
+				  Q_ARG(bool, toggle));
 }
 
 void t_gui::do_retrieve(void) {
@@ -657,17 +658,21 @@ void t_gui::gui_do_bye(void)
 	}
 }
 
-void t_gui::gui_do_hold(void)
+void t_gui::gui_do_hold(bool toggle)
 {
-	if (mainWindow->callHold->isEnabled() && !mainWindow->callHold->isChecked()) {
-		mainWindow->phoneHold(true);
+	if (mainWindow->callHold->isEnabled()) {
+		if (toggle && mainWindow->callHold->isChecked())
+			mainWindow->phoneHold(false);
+		else
+			mainWindow->phoneHold(true);
 	}
 }
 
 void t_gui::gui_do_retrieve(void)
 {
-	if (mainWindow->callHold->isEnabled() && mainWindow->callHold->isChecked()) {
-		mainWindow->phoneHold(false);
+	if (mainWindow->callHold->isEnabled()) {
+		if (mainWindow->callHold->isChecked())
+			mainWindow->phoneHold(false);
 	}
 }
 

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -128,7 +128,7 @@ protected:
 	virtual void do_dnd(bool show_status, bool toggle, bool enable);
 	virtual void do_auto_answer(bool show_status, bool toggle, bool enable);
 	virtual void do_bye(void);
-	virtual void do_hold(void);
+	virtual void do_hold(bool toggle);
 	virtual void do_retrieve(void);
 	virtual bool do_refer(const string &destination,
 			      t_transfer_type transfer_type, bool immediate);
@@ -165,7 +165,7 @@ private slots:
 	void gui_do_dnd(bool toggle, bool enable);
 	void gui_do_auto_answer(bool toggle, bool enable);
 	void gui_do_bye(void);
-	void gui_do_hold(void);
+	void gui_do_hold(bool toggle);
 	void gui_do_retrieve(void);
 	void gui_do_refer(const QString &destination,
 			  t_transfer_type transfer_type, bool immediate);

--- a/src/userintf.cpp
+++ b/src/userintf.cpp
@@ -776,12 +776,35 @@ void t_userintf::do_bye(void) {
 }
 
 bool t_userintf::exec_hold(const list<string> command_list) {
-	do_hold();
+	list<t_command_arg> al;
+	bool toggle = false;
+
+	if (!parse_args(command_list, al)) {
+		exec_command("help hold");
+		return false;
+	}
+
+	for (list<t_command_arg>::iterator i = al.begin(); i != al.end(); i++) {
+		switch (i->flag) {
+		case 't':
+			toggle = true;
+			break;
+		default:
+			exec_command("help hold");
+			return false;
+			break;
+		}
+	}
+
+	do_hold(toggle);
 	return true;
 }
 
-void t_userintf::do_hold(void) {
-	phone->pub_hold();
+void t_userintf::do_hold(bool toggle) {
+	if (toggle && phone->is_line_on_hold(phone->get_active_line()))
+		phone->pub_retrieve();
+	else
+		phone->pub_hold();
 }
 
 bool t_userintf::exec_retrieve(const list<string> command_list) {
@@ -1668,9 +1691,13 @@ void t_userintf::do_help(const list<t_command_arg> &al) {
 	if (c == "hold") {
 		cout << endl;
 		cout << "Usage:\n";
-		cout << "\thold\n";
+		cout << "\thold [-t]\n";
 		cout << "Description:\n";
-		cout << "\tPut the current call on the acitve line on-hold.\n";
+		cout << "\tPut the current call on the active line on-hold.\n";
+		cout << "\tIf the -t flag is passed and the call is currently held,\n";
+		cout << "\tit will be retrieved instead.\n";
+		cout << "Arguments:\n";
+		cout << "\t-t		Toggle the on-hold status of a call.\n";
 		cout << endl;
 
 		return;

--- a/src/userintf.h
+++ b/src/userintf.h
@@ -142,7 +142,7 @@ protected:
 	virtual void do_dnd(bool show_status, bool toggle, bool enable);
 	virtual void do_auto_answer(bool show_status, bool toggle, bool enable);
 	virtual void do_bye(void);
-	virtual void do_hold(void);
+	virtual void do_hold(bool toggle);
 	virtual void do_retrieve(void);
 	virtual bool do_refer(const string &destination, t_transfer_type transfer_type, 
 		bool immediate);


### PR DESCRIPTION
This makes it easy to create a single "hold/retrieve" keyboard shortcut.