### PR TITLE
Add new TWINKLE_* service-based environment variables

### DIFF
--- a/src/call_script.cpp
+++ b/src/call_script.cpp
@@ -170,11 +170,20 @@ char **t_call_script::create_env(t_sip_message *m) const {
 		var_twinkle += m->hdr_to.display;
 		l.push_back(var_twinkle);
 		
-		environ_size += l.size();
+		// Add Twinkle specific environment variables
+		var_twinkle = "TWINKLE_USER_PROFILE=";
+		var_twinkle += user_config->get_profile_name();
+		l.push_back(var_twinkle);
+
+		var_twinkle = "TWINKLE_TRIGGER=";
+		var_twinkle += trigger2str(trigger);
+		l.push_back(var_twinkle);
+
+		var_twinkle = "TWINKLE_LINE=";
+		var_twinkle += ulong2str(line_number);
+		l.push_back(var_twinkle);
 		
-		// Number of Twinkle environment variables
-		int start_twinkle_env = environ_size; // Position of Twinkle variables
-		environ_size += 3;
+		environ_size += l.size();
 		
 		// MEMMAN not called on purpose
 		char **env = new char *[environ_size + 1];
@@ -189,19 +198,6 @@ char **t_call_script::create_env(t_sip_message *m) const {
 		for (list<string>::iterator i = l.begin(); i != l.end(); i++, j++) {
 			env[j] = strdup(i->c_str());
 		}
-		
-		// Add Twinkle specific environment variables
-		var_twinkle = "TWINKLE_USER_PROFILE=";
-		var_twinkle += user_config->get_profile_name();
-		env[start_twinkle_env] = strdup(var_twinkle.c_str());
-		
-		var_twinkle = "TWINKLE_TRIGGER=";
-		var_twinkle += trigger2str(trigger);
-		env[start_twinkle_env + 1] = strdup(var_twinkle.c_str());
-		
-		var_twinkle = "TWINKLE_LINE=";
-		var_twinkle += ulong2str(line_number);
-		env[start_twinkle_env + 2] = strdup(var_twinkle.c_str());
 		
 		// Terminate array with NULL
 		env[environ_size] = NULL;

--- a/src/call_script.h
+++ b/src/call_script.h
@@ -29,6 +29,11 @@
    TWINKLE_USER_PROFILE=<user profile name>
    TWINKLE_TRIGGER=<trigger type>
    TWINKLE_LINE=<line number (starting at 1) associated with the call>
+   TWINKLE_DO_NOT_DISTURB=<"1" if "Do not disturb" is enabled>
+   TWINKLE_AUTO_ANSWER=<"1" if "Auto answer" is enabled>
+   TWINKLE_REDIRECT_ALWAYS=<destination list for "Unconditional" call redirection>
+   TWINKLE_REDIRECT_BUSY=<destination list for "When busy" call redirection>
+   TWINKLE_REDIRECT_NO_ANSWER=<destination list for "No answer" call redirection>
    SIPREQUEST_METHOD=<method>
    SIPREQUEST_URI=<request uri>
    SIPSTATUS_CODE=<status code of a response>
@@ -66,6 +71,7 @@
 
 #include <vector>
 #include <string>
+#include "sockets/url.h"
 #include "user.h"
 #include "parser/request.h"
 
@@ -149,6 +155,14 @@ private:
 	 * @return String representation for the trigger.
 	 */
 	string trigger2str(t_trigger t) const;
+	
+	/**
+	 * Converts a list of call forwarding destinations to a single string,
+	 * with multiple destinations separated by commas.
+	 * @param cf_dest [in] List of call forwarding destinations
+	 * @return String representation of the destinations list
+	 */
+	string cf_dest2str(const list<t_display_url> &cf_dest) const;
 	
 	/**
 	 * Create environment for the process running the script.


### PR DESCRIPTION
Create additional environment variables when invoking a call script,
based on the services enabled for that call's user:

  - TWINKLE_DO_NOT_DISTURB:
      Set to "1" if "Do not disturb" is enabled.

  - TWINKLE_AUTO_ANSWER:
      Set to "1" if "Auto answer" is enabled.

  - TWINKLE_REDIRECT_ALWAYS:
  - TWINKLE_REDIRECT_BUSY:
  - TWINKLE_REDIRECT_NO_ANSWER:
      If the corresponding call redirection feature is enabled, contains
      the list of all destinations, separated by commas.

Each variable is set to an empty string if its corresponding feature is
disabled.
