### PR TITLE
Bump up MAX_LEN_LOG_STRING to 4096 bytes

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -47,7 +47,7 @@ enum t_log_class {
 class t_log {
 private:
 	/** Maximum length of a logged string (bytes) */
-	static const string::size_type MAX_LEN_LOG_STRING = 1024;
+	static const string::size_type MAX_LEN_LOG_STRING = 4096;
 
         string          log_filename;
         ofstream        *log_stream;


### PR DESCRIPTION
This limit of 1024 bytes is rather small, resulting in most SDP packets
being truncated in my case.  This can be problematic during debugging,
such as in #226.