### PR TITLE
CI: Switch bcg729 repo from linphone.org to GitHub mirror

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Download and build bcg729 (${{ matrix.bcg729-branch || 'n/a' }})
         if: ${{ matrix.bcg729-branch }}
         run: |
-          git clone https://gitlab.linphone.org/BC/public/bcg729.git \
+          git clone https://github.com/BelledonneCommunications/bcg729.git \
                     --branch "$BCG729_BRANCH"
           cd bcg729
           if $BCG729_AUTOTOOLS; then


### PR DESCRIPTION
gitlab.linphone.org is currently unavailable (due to a faulty SSL
certificate), thus causing our whole CI workflow to fail.  Now switching
to their official GitHub mirror, to get things running again.