### PR TITLE
Add support for SIP session timers (RFC 4028)

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1272,6 +1272,21 @@ void t_gui::cb_100rel_timeout(int line) {
 	unlock();
 }
 
+void t_gui::cb_session_expired(int line) {
+	if (line >= NUM_USER_LINES) return;
+
+	lock();
+	QString s;
+
+	emit mw_display_header();
+	s = qApp->translate("GUI", "Line %1: session has expired, call will be terminated.").arg(line + 1);
+	emit mw_display(s);
+
+	cb_stop_call_notification(line);
+
+	unlock();
+}
+
 void t_gui::cb_prack_failed(int line, const t_response *r) {
 	if (line >= NUM_USER_LINES) return;
 	

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -221,6 +221,7 @@ public:
 	void cb_unsupported_content_type(int line, const t_sip_message *r);
 	void cb_ack_timeout(int line);
 	void cb_100rel_timeout(int line);
+	void cb_session_expired(int line);
 	void cb_prack_failed(int line, const t_response *r);
 	void cb_provisional_resp_invite(int line, const t_response *r);
 	void cb_cancel_failed(int line, const t_response *r);

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -36,6 +36,7 @@ set(LIBTWINKLE_PARSER-SRCS
 	hdr_in_reply_to.cpp
 	hdr_max_forwards.cpp
 	hdr_min_expires.cpp
+	hdr_min_se.cpp
 	hdr_mime_version.cpp
 	hdr_organization.cpp
 	hdr_priority.cpp
@@ -59,6 +60,7 @@ set(LIBTWINKLE_PARSER-SRCS
 	hdr_rseq.cpp
 	hdr_server.cpp
 	hdr_service_route.cpp
+	hdr_session_expires.cpp
 	hdr_sip_etag.cpp
 	hdr_sip_if_match.cpp
 	hdr_subject.cpp

--- a/src/parser/hdr_min_se.cpp
+++ b/src/parser/hdr_min_se.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2005-2009  Michel de Boer <michel@twinklephone.com>
+    Copyright (C) 2022       Frédéric Brière <fbriere@fbriere.net>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,35 +16,35 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-// Supported header
+#include "definitions.h"
+#include "hdr_min_se.h"
+#include "util.h"
 
-#ifndef _H_HDR_SUPPORTED
-#define _H_HDR_SUPPORTED
+t_hdr_min_se::t_hdr_min_se() :
+	t_header("Min-SE"),
+	time(90)
+{
+}
 
-#include <list>
-#include <string>
-#include "header.h"
+void t_hdr_min_se::set_time(unsigned long t) {
+	populated = true;
+	time = t;
+}
 
-#define EXT_100REL	"100rel"	// RFC 3262
-#define EXT_REPLACES	"replaces"	// RFC 3891
-#define EXT_TIMER	"timer"		// RFC 4028
-#define EXT_NOREFERSUB	"norefersub"	// RFC 4488
+void t_hdr_min_se::add_param(const t_parameter &p) {
+	params.push_back(p);
+}
 
-class t_hdr_supported : public t_header {
-public:
-	list<string>	features;
+void t_hdr_min_se::set_params(const std::list<t_parameter> &l) {
+	params = l;
+}
 
-	t_hdr_supported();
-	void add_feature(const string &f);
-	void add_features(const list<string> &l);
+string t_hdr_min_se::encode_value(void) const {
+	if (!populated) return "";
 
-	// Clear the list of features, but make the header 'populated'.
-	// An empty header will be in the message.
-	void set_empty(void);
+	string s;
+	s += ulong2str(time);
+	s += param_list2str(params);
 
-	bool contains(const string &f) const;
-	
-	string encode_value(void) const;
-};
-
-#endif
+	return s;
+}

--- a/src/parser/hdr_min_se.h
+++ b/src/parser/hdr_min_se.h
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2005-2009  Michel de Boer <michel@twinklephone.com>
+    Copyright (C) 2022       Frédéric Brière <fbriere@fbriere.net>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,35 +16,29 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-// Supported header
+// Min-SE header (RFC 4028)
 
-#ifndef _H_HDR_SUPPORTED
-#define _H_HDR_SUPPORTED
+#ifndef _HDR_MIN_SE_H
+#define _HDR_MIN_SE_H
 
 #include <list>
 #include <string>
 #include "header.h"
+#include "parameter.h"
 
-#define EXT_100REL	"100rel"	// RFC 3262
-#define EXT_REPLACES	"replaces"	// RFC 3891
-#define EXT_TIMER	"timer"		// RFC 4028
-#define EXT_NOREFERSUB	"norefersub"	// RFC 4488
-
-class t_hdr_supported : public t_header {
+class t_hdr_min_se : public t_header {
 public:
-	list<string>	features;
+	unsigned long time; // expiry time in seconds
+	list<t_parameter> params;
 
-	t_hdr_supported();
-	void add_feature(const string &f);
-	void add_features(const list<string> &l);
+	t_hdr_min_se();
 
-	// Clear the list of features, but make the header 'populated'.
-	// An empty header will be in the message.
-	void set_empty(void);
+	void set_time(unsigned long t);
 
-	bool contains(const string &f) const;
-	
-	string encode_value(void) const;
+	void add_param(const t_parameter &p);
+	void set_params(const std::list<t_parameter> &l);
+
+	std::string encode_value(void) const;
 };
 
 #endif

--- a/src/parser/hdr_session_expires.cpp
+++ b/src/parser/hdr_session_expires.cpp
@@ -1,0 +1,88 @@
+/*
+    Copyright (C) 2005-2009  Michel de Boer <michel@twinklephone.com>
+    Copyright (C) 2022       Frédéric Brière <fbriere@fbriere.net>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "definitions.h"
+#include "hdr_session_expires.h"
+#include "util.h"
+
+t_hdr_session_expires::t_hdr_session_expires() :
+	t_header("Session-Expires", "x"),
+	time(0),
+	refresher(REFRESHER_NONE)
+{
+}
+
+void t_hdr_session_expires::set_time(unsigned long t) {
+	populated = true;
+	time = t;
+}
+
+void t_hdr_session_expires::set_refresher(t_refresher r) {
+	refresher = r;
+}
+
+bool t_hdr_session_expires::set_refresher(const std::string &r) {
+	if (r == SE_REFRESHER_UAS) {
+		if (refresher == REFRESHER_UAC) return false;
+		set_refresher(REFRESHER_UAS);
+		return true;
+	}
+
+	if (r == SE_REFRESHER_UAC) {
+		if (refresher == REFRESHER_UAS) return false;
+		set_refresher(REFRESHER_UAC);
+		return true;
+	}
+
+	return false;
+}
+
+void t_hdr_session_expires::add_param(const t_parameter &p) {
+	params.push_back(p);
+}
+
+void t_hdr_session_expires::set_params(const std::list<t_parameter> &l) {
+	params = l;
+}
+
+string t_hdr_session_expires::encode_value(void) const {
+	if (!populated) return "";
+
+	string s;
+
+	std::list<t_parameter> p = params;
+
+	std::string refresher_str;
+	switch (refresher) {
+		case REFRESHER_UAS:
+			refresher_str = SE_REFRESHER_UAS;
+			break;
+		case REFRESHER_UAC:
+			refresher_str = SE_REFRESHER_UAC;
+			break;
+	}
+	if (!refresher_str.empty()) {
+		t_parameter r("refresher", refresher_str);
+		p.push_front(r);
+	}
+
+	s += ulong2str(time);
+	s += param_list2str(p);
+
+	return s;
+}

--- a/src/parser/hdr_session_expires.h
+++ b/src/parser/hdr_session_expires.h
@@ -1,5 +1,6 @@
 /*
     Copyright (C) 2005-2009  Michel de Boer <michel@twinklephone.com>
+    Copyright (C) 2022       Frédéric Brière <fbriere@fbriere.net>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,35 +16,41 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-// Supported header
+// Session-Expires header (RFC 4028)
 
-#ifndef _H_HDR_SUPPORTED
-#define _H_HDR_SUPPORTED
+#ifndef _HDR_SESSION_EXPIRES_H
+#define _HDR_SESSION_EXPIRES_H
 
 #include <list>
 #include <string>
 #include "header.h"
+#include "parameter.h"
 
-#define EXT_100REL	"100rel"	// RFC 3262
-#define EXT_REPLACES	"replaces"	// RFC 3891
-#define EXT_TIMER	"timer"		// RFC 4028
-#define EXT_NOREFERSUB	"norefersub"	// RFC 4488
+#define SE_REFRESHER_UAS	"uas"
+#define SE_REFRESHER_UAC	"uac"
 
-class t_hdr_supported : public t_header {
+class t_hdr_session_expires : public t_header {
 public:
-	list<string>	features;
+	enum t_refresher {
+		REFRESHER_NONE,
+		REFRESHER_UAS,
+		REFRESHER_UAC
+	};
 
-	t_hdr_supported();
-	void add_feature(const string &f);
-	void add_features(const list<string> &l);
+	unsigned long time; // expiry time in seconds
+	t_refresher refresher;
+	list<t_parameter> params;
 
-	// Clear the list of features, but make the header 'populated'.
-	// An empty header will be in the message.
-	void set_empty(void);
+	t_hdr_session_expires();
 
-	bool contains(const string &f) const;
-	
-	string encode_value(void) const;
+	void set_time(unsigned long t);
+	void set_refresher(t_refresher r);
+	bool set_refresher(const std::string &r);
+
+	void add_param(const t_parameter &p);
+	void set_params(const std::list<t_parameter> &l);
+
+	std::string encode_value(void) const;
 };
 
 #endif

--- a/src/parser/parser.yxx
+++ b/src/parser/parser.yxx
@@ -116,6 +116,7 @@ void yyerror(const char *s);
 %token			T_HDR_IN_REPLY_TO
 %token			T_HDR_MAX_FORWARDS
 %token			T_HDR_MIN_EXPIRES
+%token			T_HDR_MIN_SE
 %token			T_HDR_MIME_VERSION
 %token			T_HDR_ORGANIZATION
 %token			T_HDR_P_ASSERTED_IDENTITY
@@ -139,6 +140,7 @@ void yyerror(const char *s);
 %token			T_HDR_ROUTE
 %token			T_HDR_RSEQ
 %token			T_HDR_SERVER
+%token			T_HDR_SESSION_EXPIRES
 %token			T_HDR_SIP_ETAG
 %token			T_HDR_SIP_IF_MATCH
 %token			T_HDR_SUBJECT
@@ -343,6 +345,7 @@ header:		  hd_accept hdr_accept T_CRLF
 		| hd_in_reply_to hdr_in_reply_to T_CRLF
 		| hd_max_forwards hdr_max_forwards T_CRLF
 		| hd_min_expires hdr_min_expires T_CRLF
+		| hd_min_se hdr_min_se T_CRLF
 		| hd_mime_version hdr_mime_version T_CRLF
 		| hd_organization hdr_organization T_CRLF
 		| hd_p_asserted_identity hdr_p_asserted_identity T_CRLF
@@ -366,6 +369,7 @@ header:		  hd_accept hdr_accept T_CRLF
 		| hd_rseq hdr_rseq T_CRLF
 		| hd_server hdr_server T_CRLF
 		| hd_service_route hdr_service_route T_CRLF
+		| hd_session_expires hdr_session_expires T_CRLF
 		| hd_sip_etag hdr_sip_etag T_CRLF
 		| hd_sip_if_match hdr_sip_if_match T_CRLF
 		| hd_subject hdr_subject T_CRLF
@@ -432,6 +436,8 @@ header:		  hd_accept hdr_accept T_CRLF
 			{ PARSE_ERROR("Max-Forwards"); }
 		| hd_min_expires error T_CRLF
 			{ PARSE_ERROR("Min-Expires"); }
+		| hd_min_se error T_CRLF
+			{ PARSE_ERROR("Min-SE"); }
 		| hd_mime_version error T_CRLF
 			{ PARSE_ERROR("MIME-Version"); }
 		| hd_organization error T_CRLF
@@ -478,6 +484,8 @@ header:		  hd_accept hdr_accept T_CRLF
 			{ PARSE_ERROR("Server"); }
 		| hd_service_route error T_CRLF
 			{ PARSE_ERROR("Service-Route"); }
+		| hd_session_expires error T_CRLF
+			{ PARSE_ERROR("Session-Expires"); }
 		| hd_sip_etag error T_CRLF
 			{ PARSE_ERROR("SIP-ETag"); }
 		| hd_sip_if_match error T_CRLF
@@ -563,6 +571,8 @@ hd_max_forwards:	T_HDR_MAX_FORWARDS ':' { CTXT_NUM; }
 ;
 hd_min_expires:		T_HDR_MIN_EXPIRES ':' { CTXT_NUM; }
 ;
+hd_min_se:		T_HDR_MIN_SE ':' { CTXT_NUM; }
+;
 hd_mime_version:	T_HDR_MIME_VERSION ':'
 ;
 hd_organization:	T_HDR_ORGANIZATION ':' { CTXT_LINE; }
@@ -608,6 +618,8 @@ hd_rseq:		T_HDR_RSEQ ':' { CTXT_NUM; }
 hd_server:		T_HDR_SERVER ':'
 ;
 hd_service_route:	T_HDR_SERVICE_ROUTE ':' { CTXT_URI; }
+;
+hd_session_expires:	T_HDR_SESSION_EXPIRES ':' { CTXT_NUM; }
 ;
 hd_sip_etag:		T_HDR_SIP_ETAG ':'
 ;
@@ -1005,6 +1017,12 @@ hdr_min_expires:  { CTXT_NUM; } T_NUM { CTXT_INITIAL; } {
 			MSG->hdr_min_expires.set_time($2); }
 ;
 
+hdr_min_se:	{ CTXT_NUM; } T_NUM { CTXT_INITIAL; } parameters {
+			MSG->hdr_min_se.set_time($2);
+			MSG->hdr_min_se.set_params(*$4);
+			MEMMAN_DELETE($4); delete $4; }
+;
+
 hdr_mime_version: T_TOKEN {
 			MSG->hdr_mime_version.set_version(*$1);
 			MEMMAN_DELETE($1); delete $1; }
@@ -1181,6 +1199,19 @@ server:		  comment {
 			$$->comment = *$4;
 			MEMMAN_DELETE($1); delete $1;
 			MEMMAN_DELETE($3); delete $3;
+			MEMMAN_DELETE($4); delete $4; }
+;
+
+hdr_session_expires:	{ CTXT_NUM; } T_NUM { CTXT_INITIAL; } parameters {
+			MSG->hdr_session_expires.set_time($2);
+			list<t_parameter>::const_iterator i;
+			for (i = $4->begin(); i != $4->end(); i++) {
+				if (i->name == "refresher") {
+					MSG->hdr_session_expires.set_refresher(i->value);
+				} else {
+					MSG->hdr_session_expires.add_param(*i);
+				}
+			}
 			MEMMAN_DELETE($4); delete $4; }
 ;
 

--- a/src/parser/response.cpp
+++ b/src/parser/response.cpp
@@ -65,6 +65,7 @@ t_response::t_response(int _code, string _reason) : t_sip_message() {
 		case 416: reason = REASON_416; break;
 		case 420: reason = REASON_420; break;
 		case 421: reason = REASON_421; break;
+		case 422: reason = REASON_422; break;
 		case 423: reason = REASON_423; break;
 		case 480: reason = REASON_480; break;
 		case 481: reason = REASON_481; break;

--- a/src/parser/response.h
+++ b/src/parser/response.h
@@ -62,6 +62,7 @@ using namespace std;
 #define	R_416_UNSUPPORTED_URI_SCHEME 416
 #define	R_420_BAD_EXTENSION 420
 #define	R_421_EXTENSION_REQUIRED 421
+#define	R_422_SESSION_INTERVAL_TOO_SMALL 422
 #define	R_423_INTERVAL_TOO_BRIEF 423
 #define	R_480_TEMP_NOT_AVAILABLE 480
 #define	R_481_TRANSACTION_NOT_EXIST 481
@@ -132,6 +133,7 @@ using namespace std;
 #define REASON_416 "Unsupported URI Scheme"
 #define REASON_420 "Bad Extension"
 #define REASON_421 "Extension Required"
+#define REASON_422 "Session Interval Too Small"
 #define REASON_423 "Interval Too Brief"
 #define REASON_480 "Temporarily Not Available"
 #define REASON_481 "Call Leg/Transaction Does Not Exist"

--- a/src/parser/scanner.lxx
+++ b/src/parser/scanner.lxx
@@ -97,6 +97,7 @@ WORD_SYM	[[:alnum:]\-\.!%\*_\+\`\'~\(\)<>:\\\"\/\[\]\?\{\}]
 ^In-Reply-To		{ return T_HDR_IN_REPLY_TO; }
 ^Max-Forwards		{ return T_HDR_MAX_FORWARDS; }
 ^Min-Expires		{ return T_HDR_MIN_EXPIRES; }
+^Min-SE			{ return T_HDR_MIN_SE; }
 ^MIME-Version		{ return T_HDR_MIME_VERSION; }
 ^Organization		{ return T_HDR_ORGANIZATION; }
 ^P-Asserted-Identity	{ return T_HDR_P_ASSERTED_IDENTITY; }
@@ -120,6 +121,7 @@ WORD_SYM	[[:alnum:]\-\.!%\*_\+\`\'~\(\)<>:\\\"\/\[\]\?\{\}]
 ^Route			{ return T_HDR_ROUTE; }
 ^RSeq			{ return T_HDR_RSEQ; }
 ^Server			{ return T_HDR_SERVER; }
+^(Session-Expires)|x	{ return T_HDR_SESSION_EXPIRES; }
 ^SIP-ETag		{ return T_HDR_SIP_ETAG; }
 ^SIP-If-Match		{ return T_HDR_SIP_IF_MATCH; }
 ^(Subject)|s		{ return T_HDR_SUBJECT; }

--- a/src/parser/sip_message.cpp
+++ b/src/parser/sip_message.cpp
@@ -66,6 +66,7 @@ t_sip_message::t_sip_message(const t_sip_message& m) :
 		hdr_in_reply_to(m.hdr_in_reply_to),
 		hdr_max_forwards(m.hdr_max_forwards),
 		hdr_min_expires(m.hdr_min_expires),
+		hdr_min_se(m.hdr_min_se),
 		hdr_mime_version(m.hdr_mime_version),
 		hdr_organization(m.hdr_organization),
 		hdr_p_asserted_identity(m.hdr_p_asserted_identity),
@@ -89,6 +90,7 @@ t_sip_message::t_sip_message(const t_sip_message& m) :
 		hdr_rseq(m.hdr_rseq),
 		hdr_server(m.hdr_server),
 		hdr_service_route(m.hdr_service_route),
+		hdr_session_expires(m.hdr_session_expires),
 		hdr_sip_etag(m.hdr_sip_etag),
 		hdr_sip_if_match(m.hdr_sip_if_match),
 		hdr_subject(m.hdr_subject),
@@ -232,6 +234,7 @@ string t_sip_message::encode(bool add_content_length) {
 	s += hdr_expires.encode();
 	s += hdr_in_reply_to.encode();
 	s += hdr_min_expires.encode();
+	s += hdr_min_se.encode();
 	s += hdr_mime_version.encode();
 	s += hdr_organization.encode();
 	s += hdr_priority.encode();
@@ -246,6 +249,7 @@ string t_sip_message::encode(bool add_content_length) {
 	s += hdr_retry_after.encode();
 	s += hdr_rseq.encode();
 	s += hdr_server.encode();
+	s += hdr_session_expires.encode();
 	s += hdr_sip_etag.encode();
 	s += hdr_sip_if_match.encode();
 	s += hdr_subject.encode();
@@ -339,6 +343,7 @@ list<string> t_sip_message::encode_env(void) {
 	l.push_back(hdr_expires.encode_env());
 	l.push_back(hdr_in_reply_to.encode_env());
 	l.push_back(hdr_min_expires.encode_env());
+	l.push_back(hdr_min_se.encode_env());
 	l.push_back(hdr_mime_version.encode_env());
 	l.push_back(hdr_organization.encode_env());
 	l.push_back(hdr_priority.encode_env());
@@ -353,6 +358,7 @@ list<string> t_sip_message::encode_env(void) {
 	l.push_back(hdr_retry_after.encode_env());
 	l.push_back(hdr_rseq.encode_env());
 	l.push_back(hdr_server.encode_env());
+	l.push_back(hdr_session_expires.encode_env());
 	l.push_back(hdr_sip_etag.encode_env());
 	l.push_back(hdr_sip_if_match.encode_env());
 	l.push_back(hdr_subject.encode_env());

--- a/src/parser/sip_message.h
+++ b/src/parser/sip_message.h
@@ -48,6 +48,7 @@
 #include "hdr_in_reply_to.h"
 #include "hdr_max_forwards.h"
 #include "hdr_min_expires.h"
+#include "hdr_min_se.h"
 #include "hdr_mime_version.h"
 #include "hdr_organization.h"
 #include "hdr_p_asserted_identity.h"
@@ -71,6 +72,7 @@
 #include "hdr_rseq.h"
 #include "hdr_server.h"
 #include "hdr_service_route.h"
+#include "hdr_session_expires.h"
 #include "hdr_sip_etag.h"
 #include "hdr_sip_if_match.h"
 #include "hdr_subject.h"
@@ -143,6 +145,7 @@ public:
 	t_hdr_in_reply_to	hdr_in_reply_to;
 	t_hdr_max_forwards	hdr_max_forwards;
 	t_hdr_min_expires	hdr_min_expires;
+	t_hdr_min_se		hdr_min_se;
 	t_hdr_mime_version	hdr_mime_version;
 	t_hdr_organization	hdr_organization;
 	t_hdr_p_asserted_identity hdr_p_asserted_identity;
@@ -166,6 +169,7 @@ public:
 	t_hdr_rseq		hdr_rseq;
 	t_hdr_server		hdr_server;
 	t_hdr_service_route	hdr_service_route;
+	t_hdr_session_expires	hdr_session_expires;
 	t_hdr_sip_etag		hdr_sip_etag;
 	t_hdr_sip_if_match	hdr_sip_if_match;
 	t_hdr_subject		hdr_subject;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -136,6 +136,8 @@ enum t_line_timer {
 	LTMR_100REL_GUARD,	/**< After this timer PRACK is lost for good */
 	LTMR_GLARE_RETRY,	/**< Waiting before retry re-INVITE after glare */
 	LTMR_CANCEL_GUARD,	/**< Guard for situation where CANCEL has been responded to, but 487 on INVITE is never received. */
+	LTMR_SESSION_REFRESH,	/**< Time to send a Session Refresh Request */
+	LTMR_SESSION_EXPIRE,	/**< Session Expiration */
 };
 
 /** Subscription timers. */
@@ -232,6 +234,9 @@ enum t_stun_timer {
 // that the subscription will be cleaned up.
 #define DUR_UNSUBSCRIBE_GUARD	4000
 
+// Minimum interval for Session-Expires
+#define MIN_SESSION_INTERVAL	90
+
 // RFC 3489
 // STUN retransmission timer intervals (ms)
 // The RFC states that the interval should start at 100ms. But that
@@ -314,6 +319,7 @@ enum t_stun_timer {
 					(h).add_feature(EXT_REPLACES);\
 				  }\
 				  (h).add_feature(EXT_NOREFERSUB);\
+				  (h).add_feature(EXT_TIMER);\
 				}
 
 // Set Accept header with accepted body types

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -217,6 +217,16 @@ t_session *t_session::create_call_retrieve(void) const {
 	return s;
 }
 
+t_session *t_session::create_session_refresh(void) const {
+	t_session *s = new t_session(*this);
+	MEMMAN_NEW(s);
+
+	// Do not copy the RTP session
+	s->set_audio_session(NULL);
+
+	return s;
+}
+
 t_session *t_session::create_clean_copy(void) const {
 	t_session *s = new t_session(*this);
 	MEMMAN_NEW(s);

--- a/src/session.h
+++ b/src/session.h
@@ -150,6 +150,9 @@ public:
 	 * @return The call-retrieve session.
 	 */
 	t_session *create_call_retrieve(void) const;
+
+	/** Create an identical copy for a session refresh re-INVITE */
+	t_session *create_session_refresh(void) const;
 	//@}
 
 	// Process incoming SDP offer. Return false if SDP is not

--- a/src/timekeeper.cpp
+++ b/src/timekeeper.cpp
@@ -220,6 +220,8 @@ string t_tmr_line::get_name(void) const {
 	case LTMR_100REL_GUARD:		return "LTMR_100REL_GUARD";
 	case LTMR_CANCEL_GUARD:		return "LTMR_CANCEL_GUARD";
 	case LTMR_GLARE_RETRY:		return "LTMR_GLARE_RETRY";
+	case LTMR_SESSION_REFRESH:	return "LTMR_SESSION_REFRESH";
+	case LTMR_SESSION_EXPIRE:	return "LTMR_SESSION_EXPIRE";
 	}
 
 	return "UNKNOWN";

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -3037,6 +3037,8 @@ bool t_user::check_required_ext(t_request *r, list<string> &unsupported) const {
 			if (ext_replaces) continue;
 		} else if (*i == EXT_NOREFERSUB) {
 			continue;
+		} else if (*i == EXT_TIMER) {
+			continue;
 		}
 
 		// Extension is not supported

--- a/src/userintf.cpp
+++ b/src/userintf.cpp
@@ -2558,6 +2558,18 @@ void t_userintf::cb_100rel_timeout(int line) {
 	cb_stop_call_notification(line);
 }
 
+void t_userintf::cb_session_expired(int line) {
+	if (line >= NUM_USER_LINES) return;
+
+	cout << endl;
+	cout << "Line " << line + 1 << ": ";
+	cout << "session has expired, call will be terminated.\n";
+	cout << endl;
+	cout.flush();
+
+	cb_stop_call_notification(line);
+}
+
 void t_userintf::cb_prack_failed(int line, const t_response *r) {
 	if (line >= NUM_USER_LINES) return;
 	

--- a/src/userintf.h
+++ b/src/userintf.h
@@ -237,6 +237,7 @@ public:
 	virtual void cb_unsupported_content_type(int line, const t_sip_message *r);
         virtual void cb_ack_timeout(int line);
 	virtual void cb_100rel_timeout(int line);
+	virtual void cb_session_expired(int line);
 	virtual void cb_prack_failed(int line, const t_response *r);
         virtual void cb_provisional_resp_invite(int line, const t_response *r);
         virtual void cb_cancel_failed(int line, const t_response *r);


### PR DESCRIPTION
Some points worth mentioning:

 - No particular support for 422 responses is provided, and retrying
   with a different Min-SE will not be performed.  (It shouldn't matter
   anyway, since we never request any session timer on our own.)

 - Session refresh requests will not be retried beyond what is already
   automatically performed by the current codebase.

 - Twinkle will probably crash or misbehave if a hold/retrieve operation
   is requested while a outgoing session refresh request is awaiting
   acknowledgement.  (This would involve two concurrent re-INVITEs,
   which Twinkle does not support.)  This situation is very unlikely,
   but still theoretically possible.

Closes #261