### PR TITLE
Add missing `$$` initializations in `sdp_parser.yxx`

### DIFF
--- a/src/sdp/sdp_parser.yxx
+++ b/src/sdp/sdp_parser.yxx
@@ -195,6 +195,7 @@ sess_attributes:  attributes {
 
 attributes:	  /* emtpy */	{ $$ = new list<t_sdp_attr>; MEMMAN_NEW($$); }
 		| attributes attribute {
+			$$ = $1;
 			$$->push_back(*$2);
 			MEMMAN_DELETE($2); delete $2; }
 ;
@@ -269,6 +270,7 @@ transport:	  T_TOKEN {
 // non-numerical formats are possible.
 formats:	  /* empty */	{ $$ = new list<string>; MEMMAN_NEW($$); }
 		| formats T_TOKEN {
+			$$ = $1;
 			$$->push_back(*$2);
 			MEMMAN_DELETE($2);
 			delete $2; }


### PR DESCRIPTION
These two rules used `$$` without ever initializing it, which is Not
Good™.  They happened to work nonetheless due to the fact that `yyval`
still contained the value returned by `$1` at that point, but that
should definitely not be relied on.

This also gets rid of the `unused value: $1 [-Wother]` warnings.