### PR TITLE
Add `cmake_minimum_required()` `policy_max` argument to silence warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(twinkle)
+cmake_minimum_required(VERSION 2.8.10...3.22 FATAL_ERROR)
 
-cmake_minimum_required(VERSION 2.8.10 FATAL_ERROR)
+project(twinkle)
 
 set(PRODUCT_VERSION "1.10.3")
 set(PRODUCT_DATE    "February 18, 2022")


### PR DESCRIPTION
This basically lets CMake know that, while we don't require any version
higher than `2.8.10`, we are still compatible with all polices present
in `3.22`.

(Although support for this argument was added in 3.12, older CMake
versions simply ignore it instead of breaking.)

We also take the opportunity to move the call above `project()`, as
recommended by the documentation.