### PR TITLE
Properly manage session timers if an early session was established

### DIFF
--- a/src/dialog.cpp
+++ b/src/dialog.cpp
@@ -1556,6 +1556,9 @@ void t_dialog::state_early(t_response *r, t_tuid tuid, t_tid tid) {
 			line->ci_set_refer_supported(true);
 		}
 		
+		// This was a response to a session refresh request (INVITE)
+		process_session_refresh_response(r);
+
 		// Trigger call script
 		script_out_call_answered.exec_notify(r);
 


### PR DESCRIPTION
The handling of a 2xx response to our initial INVITE will take place at
one of two different code locations, depending on whether or not an
early session has been established beforehand.  Both should therefore
include a call to `process_session_refresh_response()`, one of which was
missing in commit 24e5c7c27ecb16cda5c9462ea409b8bfebb65c5d (#262).

Closes #277