### PR TITLE
Use `typedef`s instead of `unsigned long` for 32-bit IPv4 addresses

### DIFF
--- a/src/abstract_dialog.cpp
+++ b/src/abstract_dialog.cpp
@@ -22,6 +22,7 @@
 #include "log.h"
 #include "phone.h"
 #include "phone_user.h"
+#include "sockets/ipaddr.h"
 #include "util.h"
 #include "userintf.h"
 #include "audits/memman.h"
@@ -89,7 +90,7 @@ t_request *t_abstract_dialog::create_request(t_method m) {
         // local IP address should be used.
         
         // Via header
-        unsigned long local_ip = r->get_local_ip();
+        IPaddr local_ip = r->get_local_ip();
 	t_via via(USER_HOST(user_config, h_ip2str(local_ip)), PUBLIC_SIP_PORT(user_config));
 	r->hdr_via.add_via(via);
 
@@ -126,7 +127,7 @@ void t_abstract_dialog::resend_request(t_client_request *cr) {
 
 	// Create a new via-header. Otherwise the
 	// request will be seen as a retransmission
-	unsigned long local_ip = req->get_local_ip();
+	IPaddr local_ip = req->get_local_ip();
 	req->hdr_via.via_list.clear();
 	t_via via(USER_HOST(user_config, h_ip2str(local_ip)), PUBLIC_SIP_PORT(user_config));
 	req->hdr_via.add_via(via);

--- a/src/dialog.cpp
+++ b/src/dialog.cpp
@@ -32,6 +32,7 @@
 #include "audits/memman.h"
 #include "im/im_iscomposing_body.h"
 #include "sdp/sdp.h"
+#include "sockets/ipaddr.h"
 #include "sockets/socket.h"
 #include "stun/stun_transaction.h"
 
@@ -2641,7 +2642,7 @@ void t_dialog::send_invite(const t_url &to_uri, const string &to_display,
 	session->create_sdp_offer(&invite, SDP_O_USER);
 	
 	// Set Via header
-	unsigned long local_ip = invite.get_local_ip();
+	IPaddr local_ip = invite.get_local_ip();
 	t_via via(USER_HOST(user_config, h_ip2str(local_ip)), PUBLIC_SIP_PORT(user_config));
 	invite.hdr_via.add_via(via);
 	
@@ -3260,7 +3261,7 @@ bool t_dialog::stun_bind_media(void) {
 	t_user *user_config = phone_user->get_user_profile();
 	
 	try {
-		unsigned long mapped_ip;
+		IPaddr mapped_ip;
 		unsigned short mapped_port;
 		int stun_err_code;
 		string stun_err_reason;

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -482,7 +482,7 @@ t_url t_event_broken_connection::get_user_uri(void) const {
 // class t_event_tcp_ping
 ///////////////////////////////////////////////////////////
 
-t_event_tcp_ping::t_event_tcp_ping(const t_url &url, unsigned int dst_addr, unsigned short dst_port) :
+t_event_tcp_ping::t_event_tcp_ping(const t_url &url, IPaddr dst_addr, unsigned short dst_port) :
 	t_event(),
 	user_uri_(url),
 	dst_addr_(dst_addr),
@@ -497,7 +497,7 @@ t_url t_event_tcp_ping::get_user_uri(void) const {
 	return user_uri_;
 }
 
-unsigned int t_event_tcp_ping::get_dst_addr(void) const {
+IPaddr t_event_tcp_ping::get_dst_addr(void) const {
 	return dst_addr_;
 }
 
@@ -643,7 +643,7 @@ void t_event_queue::push_abort_trans(unsigned short tid) {
 void t_event_queue::push_stun_request(t_user *user_config, 
 		StunMessage *m, t_stun_event_type ev_type,
 		unsigned short tuid, unsigned short tid,
-		unsigned long ipaddr, unsigned short port, unsigned short src_port)
+		IPaddr ipaddr, unsigned short port, unsigned short src_port)
 {
 	t_event_stun_request *event = new t_event_stun_request(user_config, 
 		m, ev_type, tuid, tid);
@@ -663,7 +663,7 @@ void t_event_queue::push_stun_response(StunMessage *m,
 	push(event);
 }
 
-void t_event_queue::push_nat_keepalive(unsigned long ipaddr, unsigned short port) {
+void t_event_queue::push_nat_keepalive(IPaddr ipaddr, unsigned short port) {
 	t_event_nat_keepalive *event = new t_event_nat_keepalive();
 	MEMMAN_NEW(event);
 	event->dst_addr = ipaddr;
@@ -692,7 +692,7 @@ void t_event_queue::push_broken_connection(const t_url &user_uri) {
 	push(event);
 }
 
-void t_event_queue::push_tcp_ping(const t_url &user_uri, unsigned int dst_addr, unsigned short dst_port) 
+void t_event_queue::push_tcp_ping(const t_url &user_uri, IPaddr dst_addr, unsigned short dst_port) 
 {
 	t_event_tcp_ping *event = new t_event_tcp_ping(user_uri, dst_addr, dst_port);
 	MEMMAN_NEW(event);

--- a/src/events.h
+++ b/src/events.h
@@ -30,6 +30,7 @@
 #include "audio/audio_codecs.h"
 #include "audio/rtp_telephone_event.h"
 #include "parser/sip_message.h"
+#include "sockets/ipaddr.h"
 #include "sockets/socket.h"
 #include "sockets/url.h"
 #include "threads/mutex.h"
@@ -93,9 +94,9 @@ private:
 	t_sip_message	*msg;
 
 public:
-	unsigned int	src_addr; /**< Source IP address of the SIP message (host order). */
+	IPaddr	src_addr; /**< Source IP address of the SIP message (host order). */
 	unsigned short	src_port; /**< Source port of the SIP message (host order). */
-	unsigned int	dst_addr; /**< Destination IP address of the SIP message (host order). */
+	IPaddr	dst_addr; /**< Destination IP address of the SIP message (host order). */
 	unsigned short	dst_port; /**< Destination port of the SIP message (host order). */
 	string		transport; /**< Transport protocol */
 
@@ -365,7 +366,7 @@ private:
 	t_user			*user_config;	/**< User profile associated with this request. */
 
 public:
-	unsigned int	dst_addr;	/**< Destination address of request (host order). */
+	IPaddr	dst_addr;	/**< Destination address of request (host order). */
 	unsigned short	dst_port;	/**< Destination port of request (host order). */
 	unsigned short	src_port;	/**< Source port for media event type (host order). */
 
@@ -429,7 +430,7 @@ public:
  */
 class t_event_nat_keepalive : public t_event {
 public:
-	unsigned int	dst_addr;	/**< Destination address for keepalive (host order) */
+	IPaddr	dst_addr;	/**< Destination address for keepalive (host order) */
 	unsigned short	dst_port;	/**< Destination port (host order) */
 	
 	t_event_type get_type(void) const;
@@ -611,19 +612,19 @@ private:
 	/** The user URI (AoR) for which the ping must be sent. */
 	t_url		user_uri_;
 	
-	unsigned int	dst_addr_;	/**< Destination address for ping (host order) */
+	IPaddr	dst_addr_;	/**< Destination address for ping (host order) */
 	unsigned short	dst_port_;	/**< Destination port (host order) */
 	
 public:
 	/** Constructor */
-	t_event_tcp_ping(const t_url &url, unsigned int dst_addr, unsigned short dst_port);
+	t_event_tcp_ping(const t_url &url, IPaddr dst_addr, unsigned short dst_port);
 	
 	t_event_type get_type(void) const;
 	
 	/** @name Getters */
 	//@{
 	t_url get_user_uri(void) const;
-	unsigned int get_dst_addr(void) const;
+	IPaddr get_dst_addr(void) const;
 	unsigned short get_dst_port(void) const;
 	//@}
 };
@@ -776,7 +777,7 @@ public:
 	 */
 	void push_stun_request(t_user *user_config, StunMessage *m, t_stun_event_type ev_type,
 		unsigned short tuid, unsigned short tid,
-		unsigned long ipaddr, unsigned short port, unsigned short src_port = 0);
+		IPaddr ipaddr, unsigned short port, unsigned short src_port = 0);
 		
 	/**
 	 * Create a STUN response event.
@@ -792,7 +793,7 @@ public:
 	 * @param ipaddr [in] Destination address (host order)
 	 * @param port [in] Destination port (host order)
 	 */
-	void push_nat_keepalive(unsigned long ipaddr, unsigned short port);
+	void push_nat_keepalive(IPaddr ipaddr, unsigned short port);
 	
 	/**
 	 * Create ICMP event.
@@ -818,7 +819,7 @@ public:
 	 * @param dst_addr [in] The destination IPv4 address for the ping.
 	 * @param dst_port [in] The destination TCP port for the ping.
 	 */
-	void push_tcp_ping(const t_url &user_uri, unsigned int dst_addr, unsigned short dst_port);
+	void push_tcp_ping(const t_url &user_uri, IPaddr dst_addr, unsigned short dst_port);
 
 	/**
 	 * Pop an event from the queue. 

--- a/src/listener.cpp
+++ b/src/listener.cpp
@@ -26,6 +26,7 @@
 #include "util.h"
 #include "im/im_iscomposing_body.h"
 #include "sockets/connection_table.h"
+#include "sockets/ipaddr.h"
 #include "sockets/socket.h"
 #include "parser/parse_ctrl.h"
 #include "parser/sip_message.h"
@@ -49,7 +50,7 @@ extern t_event_queue *evq_trans_layer;
 #define TCP_BACKLOG		5
 
 void recvd_stun_msg(char *datagram, int datagram_size, 
-	unsigned long src_addr, unsigned short src_port) 
+	IPaddr src_addr, unsigned short src_port) 
 {
 	StunMessage m;
 	
@@ -298,7 +299,7 @@ static void process_sip_msg(t_sip_message *msg, const string &raw_headers, const
 void *listen_udp(void *arg) {
 	char		buf[sys_config->get_sip_max_udp_size() + 1];
 	int		data_size;
-	unsigned long	src_addr;
+	IPaddr	src_addr;
 	unsigned short	src_port;
 	t_sip_message	*msg;
 	t_event_icmp	*ev_icmp;
@@ -474,7 +475,7 @@ void *listen_for_data_tcp(void *arg) {
 		{
 			string raw_headers;
 			string raw_body;
-			unsigned long remote_addr;
+			IPaddr remote_addr;
 			unsigned short remote_port;
 			
 			(*it)->get_remote_address(remote_addr, remote_port);
@@ -583,7 +584,7 @@ void *listen_for_data_tcp(void *arg) {
 }
 
 void *listen_for_conn_requests_tcp(void *arg) {
-	unsigned long dst_addr;
+	IPaddr dst_addr;
 	unsigned short dst_port;
 	string log_msg;
 

--- a/src/parser/sip_message.cpp
+++ b/src/parser/sip_message.cpp
@@ -475,7 +475,7 @@ void t_sip_message::calc_local_ip(void) {
 	// Do nothing
 }
 
-unsigned long t_sip_message::get_local_ip(void) {
+IPaddr t_sip_message::get_local_ip(void) {
 	if (local_ip_ == 0) calc_local_ip();
 	return local_ip_;
 }

--- a/src/parser/sip_message.h
+++ b/src/parser/sip_message.h
@@ -87,6 +87,7 @@
 #include "hdr_www_authenticate.h"
 #include "parameter.h"
 #include "sip_body.h"
+#include "sockets/ipaddr.h"
 
 // Macro's to access the body of a message, eg msg.sdp_body
 #define SDP_BODY	((t_sdp *)body)
@@ -108,7 +109,7 @@ protected:
 	 * The local IP address can only be determined when the destination
 	 * of a SIP message is known (because of multi homing).
 	 */
-	unsigned long		local_ip_;
+	IPaddr		local_ip_;
 	
 public:
 	// The source IP address and port are only set for messages
@@ -267,7 +268,7 @@ public:
 	 * @return The local IP address.
 	 * @return 0, if the local IP address is not determined yet.
 	 */
-	unsigned long get_local_ip(void);
+	IPaddr get_local_ip(void);
 };
 
 #endif

--- a/src/phone_user.cpp
+++ b/src/phone_user.cpp
@@ -574,7 +574,7 @@ void t_phone_user::resend_request(t_request *req, bool is_register, t_client_req
 
 	// Create a new via-header. Otherwise the
 	// request will be seen as a retransmission
-	unsigned long local_ip = req->get_local_ip();
+	IPaddr local_ip = req->get_local_ip();
 	req->hdr_via.via_list.clear();
 	t_via via(USER_HOST(user_config, h_ip2str(local_ip)), PUBLIC_SIP_PORT(user_config));
 	req->hdr_via.add_via(via);
@@ -1442,7 +1442,7 @@ t_request *t_phone_user::create_request(t_method m, const t_url &request_uri) co
         // local IP address should be used.
 	
 	// Via
-	unsigned long local_ip = req->get_local_ip();
+	IPaddr local_ip = req->get_local_ip();
 	t_via via(USER_HOST(user_config, h_ip2str(local_ip)), PUBLIC_SIP_PORT(user_config));
 	req->hdr_via.add_via(via);
 

--- a/src/phone_user.h
+++ b/src/phone_user.h
@@ -34,6 +34,7 @@
 #include "parser/response.h"
 #include "stun/stun.h"
 #include "presence/buddy.h"
+#include "sockets/ipaddr.h"
 
 using namespace std;
 using namespace im;
@@ -195,7 +196,7 @@ public:
 	//@{
 	bool		use_stun; 		/**< Indicates if STUN must be used. */
 	bool		use_nat_keepalive; 	/**< Send NAT keepalive ? */
-	unsigned long	stun_public_ip_sip; 	/**< Public IP for SIP */
+	IPaddr	stun_public_ip_sip; 	/**< Public IP for SIP */
 	unsigned short	stun_public_port_sip; 	/**< Public port for SIP */
 	
 	/** Number of presence subscriptions using the STUN binding. */

--- a/src/sender.cpp
+++ b/src/sender.cpp
@@ -32,6 +32,7 @@
 #include "userintf.h"
 #include "util.h"
 #include "sockets/connection_table.h"
+#include "sockets/ipaddr.h"
 #include "sockets/socket.h"
 #include "parser/parse_ctrl.h"
 #include "parser/sip_message.h"
@@ -64,7 +65,7 @@ static int num_non_icmp_errors = 0;
 //
 // Returns true if the packet that failed to be sent, should still be sent.
 // Returns false if the packet that failed to be sent, should be discarded.
-static bool handle_socket_err(int err, unsigned long dst_addr, unsigned short dst_port) {
+static bool handle_socket_err(int err, IPaddr dst_addr, unsigned short dst_port) {
 	string log_msg;
 
 	// Check if an ICMP error has been received
@@ -184,7 +185,7 @@ static void send_sip_tcp(t_event *event) {
 	bool new_connection = false;
 	
 	e = (t_event_network *)event;
-	unsigned long dst_addr = e->dst_addr;
+	IPaddr dst_addr = e->dst_addr;
 	unsigned short dst_port = e->dst_port;
 	
 	assert(dst_addr != 0);
@@ -452,7 +453,7 @@ void *tcp_sender_loop(void *arg) {
 					continue;
 				}
 				
-				unsigned long remote_addr;
+				IPaddr remote_addr;
 				unsigned short remote_port;
 			
 				(*it)->get_remote_address(remote_addr, remote_port);
@@ -494,7 +495,7 @@ void *tcp_sender_loop(void *arg) {
 void *sender_loop(void *arg) {
 	t_event 	*event;
 	t_event_network	*ev_network;
-	unsigned long	local_ipaddr;
+	IPaddr	local_ipaddr;
 
 	bool quit = false;
 	while (!quit) {

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -21,6 +21,7 @@
 #include "phone.h"
 #include "phone_user.h"
 #include "session.h"
+#include "sockets/ipaddr.h"
 #include "util.h"
 #include "userintf.h"
 #include "audits/memman.h"
@@ -438,7 +439,7 @@ void t_session::create_sdp_offer(t_sip_message *m, const string &user) {
 	
 	// Determine the IP address to receive the media streams
 	if (receive_host == AUTO_IP4_ADDRESS) {
-		unsigned local_ip = m->get_local_ip();
+		IPaddr local_ip = m->get_local_ip();
 		if (local_ip == 0) {
 			log_file->write_report("Cannot determine local IP address.",
 				"t_session::create_sdp_offer", LOG_NORMAL, LOG_CRITICAL);
@@ -511,8 +512,8 @@ void t_session::create_sdp_answer(t_sip_message *m, const string &user) {
 	
 	// Determine the IP address to receive the media streams
 	if (receive_host == AUTO_IP4_ADDRESS) {
-		unsigned long local_ip = 0;
-		unsigned long dst_ip = gethostbyname(dst_rtp_host);
+		IPaddr local_ip = 0;
+		IPaddr dst_ip = gethostbyname(dst_rtp_host);
 		
 		if (dst_ip != 0)
 		{

--- a/src/sockets/connection.cpp
+++ b/src/sockets/connection.cpp
@@ -218,7 +218,7 @@ void t_connection::remove_data(size_t nbytes) {
 	}
 }
 
-void t_connection::get_remote_address(unsigned long &remote_addr, unsigned short &remote_port) {
+void t_connection::get_remote_address(IPaddr &remote_addr, unsigned short &remote_port) {
 	remote_addr = 0;
 	remote_port = 0;
 

--- a/src/sockets/connection.h
+++ b/src/sockets/connection.h
@@ -27,6 +27,7 @@
 #include <string>
 
 #include "socket.h"
+#include "sockets/ipaddr.h"
 #include "parser/request.h"
 #include "parser/sip_message.h"
 
@@ -163,7 +164,7 @@ public:
 	 * @param remote_addr [out] Source IPv4 address of the connection.
 	 * @param remote_port [out] Source port of the connection.
 	 */
-	void get_remote_address(unsigned long &remote_addr, unsigned short &remote_port);
+	void get_remote_address(IPaddr &remote_addr, unsigned short &remote_port);
 	
 	/**
 	 * Add an interval to the idle time.

--- a/src/sockets/connection_table.cpp
+++ b/src/sockets/connection_table.cpp
@@ -135,7 +135,7 @@ void t_connection_table::remove_connection(t_connection *connection) {
 	signal_modification_write();
 }
 
-t_connection *t_connection_table::get_connection(unsigned long remote_addr, 
+t_connection *t_connection_table::get_connection(IPaddr remote_addr, 
 		unsigned short remote_port)
 {
 	mtx_connections_.lock();
@@ -146,7 +146,7 @@ t_connection *t_connection_table::get_connection(unsigned long remote_addr,
 	for (list<t_connection *>::iterator it = connections_.begin();
 	     it != connections_.end(); ++it)
 	{
-		unsigned long addr;
+		IPaddr addr;
 		unsigned short port;
 
 		if ((*it)->may_reuse()) {
@@ -373,7 +373,7 @@ void t_connection_table::close_idle_connections(unsigned long interval, bool &te
 	for (list<t_connection *>::iterator it = expired_connections.begin();
 	     it != expired_connections.end(); ++it)
 	{
-		unsigned long ipaddr;
+		IPaddr ipaddr;
 		unsigned short port;
 		
 		(*it)->get_remote_address(ipaddr, port);

--- a/src/sockets/connection_table.h
+++ b/src/sockets/connection_table.h
@@ -29,6 +29,7 @@
 #include <unistd.h>
 
 #include "connection.h"
+#include "sockets/ipaddr.h"
 #include "threads/mutex.h"
 
 using namespace std;
@@ -124,7 +125,7 @@ public:
 	 *       unlock the tbale when it is finished with the connection.
 	 * @note Only re-usable connections are considered.
 	 */
-	t_connection *get_connection(unsigned long remote_addr, unsigned short remote_port);
+	t_connection *get_connection(IPaddr remote_addr, unsigned short remote_port);
 	
 	/**
 	 * Wait for connections to become readable.

--- a/src/sockets/ipaddr.h
+++ b/src/sockets/ipaddr.h
@@ -1,0 +1,9 @@
+#ifndef _H_IPADDR
+#define _H_IPADDR
+
+// IP address in host byte order
+typedef unsigned long IPaddr;
+// IP address in network byte order
+typedef unsigned long IPNaddr;
+
+#endif

--- a/src/sockets/socket.cpp
+++ b/src/sockets/socket.cpp
@@ -39,8 +39,8 @@
 // t_icmp_msg
 /////////////////
 
-t_icmp_msg::t_icmp_msg(short _type, short _code, unsigned long _icmp_src_ipaddr,
-	unsigned long _ipaddr, unsigned short _port) :
+t_icmp_msg::t_icmp_msg(short _type, short _code, IPaddr _icmp_src_ipaddr,
+	IPaddr _ipaddr, unsigned short _port) :
 		type(_type), code(_code), icmp_src_ipaddr(_icmp_src_ipaddr),
 		ipaddr(_ipaddr), port(_port)
 {}
@@ -104,7 +104,7 @@ t_socket_udp::t_socket_udp(unsigned short port) {
 	if (ret < 0) throw errno;
 }
 
-int t_socket_udp::connect(unsigned long dest_addr, unsigned short dest_port) {
+int t_socket_udp::connect(IPaddr dest_addr, unsigned short dest_port) {
 	struct sockaddr_in addr;
 	int ret;
 
@@ -117,7 +117,7 @@ int t_socket_udp::connect(unsigned long dest_addr, unsigned short dest_port) {
 	return ret;
 }
 
-int t_socket_udp::sendto(unsigned long dest_addr, unsigned short dest_port,
+int t_socket_udp::sendto(IPaddr dest_addr, unsigned short dest_port,
 	           const char *data, int data_size) {
 	struct sockaddr_in addr;
 	int ret;
@@ -139,7 +139,7 @@ ssize_t t_socket_udp::send(const void *data, int data_size) {
 	return ret;
 }
 
-int t_socket_udp::recvfrom(unsigned long &src_addr, unsigned short &src_port,
+int t_socket_udp::recvfrom(IPaddr &src_addr, unsigned short &src_port,
 		     char *buf, int buf_size) {
 	struct sockaddr_in addr;
 	int ret, len_addr;
@@ -255,9 +255,9 @@ bool t_socket_udp::get_icmp(t_icmp_msg &icmp) {
 	return false;
 }
 
-string h_ip2str(unsigned long ipaddr) {
+string h_ip2str(IPaddr ipaddr) {
 	char buf[16];
-	unsigned long x = htonl(ipaddr);
+	IPNaddr x = htonl(ipaddr);
 	unsigned char *ipbuf = (unsigned char *)&x;
 
 	snprintf(buf, 16, "%u.%u.%u.%u", ipbuf[0], ipbuf[1], ipbuf[2],
@@ -307,7 +307,7 @@ void t_socket_tcp::listen(int backlog) {
 	if (ret < 0) throw errno;
 }
 
-t_socket_tcp *t_socket_tcp::accept(unsigned long &src_addr, unsigned short &src_port) {
+t_socket_tcp *t_socket_tcp::accept(IPaddr &src_addr, unsigned short &src_port) {
 	struct sockaddr_in addr;
 	socklen_t socklen = sizeof(addr);
 	int ret = ::accept(sd, (struct sockaddr *)&addr, &socklen);
@@ -321,7 +321,7 @@ t_socket_tcp *t_socket_tcp::accept(unsigned long &src_addr, unsigned short &src_
 	return sock;
 }
 
-void t_socket_tcp::connect(unsigned long dest_addr, unsigned short dest_port) {
+void t_socket_tcp::connect(IPaddr dest_addr, unsigned short dest_port) {
 	struct sockaddr_in addr;
 	int ret;
 
@@ -348,7 +348,7 @@ ssize_t t_socket_tcp::recv(void *buf, int buf_size) {
 	return ret;
 }
 
-void t_socket_tcp::get_remote_address(unsigned long &remote_addr, unsigned short &remote_port) {
+void t_socket_tcp::get_remote_address(IPaddr &remote_addr, unsigned short &remote_port) {
 	struct sockaddr_in addr;
 	socklen_t namelen = sizeof(addr);
 	

--- a/src/sockets/socket.h
+++ b/src/sockets/socket.h
@@ -29,6 +29,8 @@
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
 
+#include "sockets/ipaddr.h"
+
 using namespace std;
 
 // ports and addresses should be in host order
@@ -40,15 +42,15 @@ public:
 	short		code;
 	
 	// ICMP source IP address
-	unsigned long	icmp_src_ipaddr;
+	IPaddr		icmp_src_ipaddr;
 	
 	// Destination IP address/port of packet causing the ICMP message.
-	unsigned long	ipaddr;
+	IPaddr		ipaddr;
 	unsigned short	port;
 	
 	t_icmp_msg() {};
-	t_icmp_msg(short _type, short _code, unsigned long _icmp_src_ipaddr,
-		unsigned long _ipaddr, unsigned short _port);
+	t_icmp_msg(short _type, short _code, IPaddr _icmp_src_ipaddr,
+		IPaddr _ipaddr, unsigned short _port);
 };
 
 /** Abstract socket */
@@ -106,17 +108,17 @@ public:
 	
 	// Connect a socket
 	// Throws an int exception if it fails (errno as set by 'sendto')
-	int connect(unsigned long dest_addr, unsigned short dest_port);
+	int connect(IPaddr dest_addr, unsigned short dest_port);
 
 	// Throws an int exception if it fails (errno as set by 'sendto')
-	int sendto(unsigned long dest_addr, unsigned short dest_port,
+	int sendto(IPaddr dest_addr, unsigned short dest_port,
 	           const char *data, int data_size);
 	virtual ssize_t send(const void *data, int data_size);
 
 	// Throws an int exception if it fails (errno as set by 'recvfrom')
 	// On success the length of the data in buf is returned. After the
 	// data in buf there will be a 0.
-	int recvfrom(unsigned long &src_addr, unsigned short &src_port,
+	int recvfrom(IPaddr &src_addr, unsigned short &src_port,
 		     char *buf, int buf_size);
 	
 	virtual ssize_t recv(void *buf, int buf_size);
@@ -170,7 +172,7 @@ public:
 	 * @return A socket for the new connection
 	 * @throw int Errno
 	 */
-	t_socket_tcp *accept(unsigned long &src_addr, unsigned short &src_port);
+	t_socket_tcp *accept(IPaddr &src_addr, unsigned short &src_port);
 	
 	/**
 	 * Connect to a destination
@@ -178,7 +180,7 @@ public:
 	 * @param dest_port [in] Destination port.
 	 * @throw int Errno
 	 */
-	void connect(unsigned long dest_addr, unsigned short dest_port);
+	void connect(IPaddr dest_addr, unsigned short dest_port);
 	
 	/** Send data */
 	virtual ssize_t send(const void *data, int data_size);
@@ -193,7 +195,7 @@ public:
 	 * @param remote_port [out] Source port of the connection.
 	 * @throw int Errno
 	 */
-	void get_remote_address(unsigned long &remote_addr, unsigned short &remote_port);
+	void get_remote_address(IPaddr &remote_addr, unsigned short &remote_port);
 };
 
 /** Local socket */
@@ -216,6 +218,6 @@ public:
 };
 
 // Convert an IP address in host order to a string.
-string h_ip2str(unsigned long ipaddr);
+string h_ip2str(IPaddr ipaddr);
 
 #endif

--- a/src/sockets/url.cpp
+++ b/src/sockets/url.cpp
@@ -42,24 +42,24 @@ unsigned short get_default_port(const string &protocol) {
 	return 0;
 }
 
-unsigned long gethostbyname(const string &name) {
+IPaddr gethostbyname(const string &name) {
 	struct hostent *h;
 	
 	h = gethostbyname(name.c_str());
 	if (h == NULL) return 0;
-	return ntohl(*((unsigned long *)h->h_addr));
+	return ntohl(*((IPNaddr *)h->h_addr));
 }
 
-list<unsigned long> gethostbyname_all(const string &name) {
+list<IPaddr> gethostbyname_all(const string &name) {
 	struct hostent *h;
-	list<unsigned long> l;
+	list<IPaddr> l;
 	
 	h = gethostbyname(name.c_str());
 	if (h == NULL) return l;
 	
 	char **ipaddr = h->h_addr_list;
 	while (*ipaddr) {
-		l.push_back(ntohl(*((unsigned long *)(*ipaddr))));
+		l.push_back(ntohl(*((IPNaddr *)(*ipaddr))));
 		ipaddr++;
 	}
 	
@@ -83,7 +83,7 @@ string get_local_hostname(void) {
 	return h->h_name;
 }
 
-unsigned long get_src_ip4_address_for_dst(unsigned long dst_ip4) {
+IPaddr get_src_ip4_address_for_dst(IPaddr dst_ip4) {
 	string log_msg;
 	struct sockaddr_in addr;
 	int ret;
@@ -157,10 +157,10 @@ string display_and_url2str(const string &display, const string &url) {
 
 // t_ip_port
 
-t_ip_port::t_ip_port(unsigned long _ipaddr, unsigned short _port) :
+t_ip_port::t_ip_port(IPaddr _ipaddr, unsigned short _port) :
 	transport("udp"), ipaddr(_ipaddr), port(_port) {}
 	
-t_ip_port::t_ip_port(const string &proto, unsigned long _ipaddr, unsigned short _port) :
+t_ip_port::t_ip_port(const string &proto, IPaddr _ipaddr, unsigned short _port) :
 	transport(proto), ipaddr(_ipaddr), port(_port) {}
 
 void t_ip_port::clear(void) {
@@ -511,7 +511,7 @@ int t_url::get_port(void) const {
 	return port;
 }
 
-unsigned long t_url::get_n_ip(void) const {
+IPNaddr t_url::get_n_ip(void) const {
 	struct hostent *h;
 
 	// TODO: handle multiple A RR's
@@ -520,16 +520,16 @@ unsigned long t_url::get_n_ip(void) const {
 	
 	h = gethostbyname(host.c_str());
 	if (h == NULL) return 0;
-	return *((unsigned long *)h->h_addr);
+	return *((IPNaddr *)h->h_addr);
 }
 
-unsigned long t_url::get_h_ip(void) const {
+IPaddr t_url::get_h_ip(void) const {
 	if (scheme == "tel") return 0;
 	return gethostbyname(host);
 }
 
-list<unsigned long> t_url::get_h_ip_all(void) const {
-	if (scheme == "tel") return list<unsigned long>();
+list<IPaddr> t_url::get_h_ip_all(void) const {
+	if (scheme == "tel") return list<IPaddr>();
 	return gethostbyname_all(host);
 }
 
@@ -548,7 +548,7 @@ string t_url::get_ip(void) const {
 list<t_ip_port> t_url::get_h_ip_srv(const string &transport) const {
 	list<t_ip_port> ip_list;
 	list<t_dns_result> srv_list;
-	list<unsigned long> ipaddr_list;
+	list<IPaddr> ipaddr_list;
 	
 	if (scheme == "tel") return list<t_ip_port>();
 		
@@ -566,7 +566,7 @@ list<t_ip_port> t_url::get_h_ip_srv(const string &transport) const {
 				// Get A RR's
 				t_ip_port ip_port;
 				ipaddr_list = gethostbyname_all(i->hostname);
-				for (list<unsigned long>::iterator j = ipaddr_list.begin();
+				for (list<IPaddr>::iterator j = ipaddr_list.begin();
 				     j != ipaddr_list.end(); j++)
 				{
 					ip_list.push_back(t_ip_port(transport, *j, i->port));
@@ -580,7 +580,7 @@ list<t_ip_port> t_url::get_h_ip_srv(const string &transport) const {
 	// No SRV RR's found, do an A RR lookup
 	t_ip_port ip_port;
 	ipaddr_list = get_h_ip_all();
-	for (list<unsigned long>::iterator j = ipaddr_list.begin();
+	for (list<IPaddr>::iterator j = ipaddr_list.begin();
 		j != ipaddr_list.end(); j++)
 	{
 		ip_list.push_back(t_ip_port(transport, *j, get_hport()));

--- a/src/sockets/url.h
+++ b/src/sockets/url.h
@@ -21,6 +21,7 @@
 #include <list>
 #include <string>
 #include "parser/header.h"
+#include "sockets/ipaddr.h"
 
 /** @name Forward declarations */
 //@{
@@ -32,15 +33,17 @@ using namespace std;
 class t_ip_port {
 public:
 	string			transport;
-	unsigned long		ipaddr;
+	IPaddr			ipaddr;
 	unsigned short		port;
 	
 	t_ip_port() : transport("udp") {};
-	t_ip_port(unsigned long _ipaddr, unsigned short _port);
-	t_ip_port(const string &proto, unsigned long _ipaddr, unsigned short _port);
+	t_ip_port(IPaddr _ipaddr, unsigned short _port);
+	t_ip_port(const string &proto, IPaddr _ipaddr, unsigned short _port);
 	
 	void clear(void);
 	bool is_null(void) const;
+	// NOTE: Equality is used only by t_phone_user::send_nat_keepalive(),
+	// to avoid sending two keep-alives to the same host
 	bool operator==(const t_ip_port &other) const;
 	bool operator!=(const t_ip_port &other) const;
 	string tostring(void) const;
@@ -51,10 +54,10 @@ unsigned short get_default_port(const string &protocol);
 
 // Return the first IP address of host name.
 // Return 0 if no IP address can be found.
-unsigned long gethostbyname(const string &name);
+IPaddr gethostbyname(const string &name);
 
 // Return all IP address of host name
-list<unsigned long> gethostbyname_all(const string &name);
+list<IPaddr> gethostbyname_all(const string &name);
 
 /**
  * Get local host name.
@@ -69,7 +72,7 @@ string get_local_hostname(void);
  * @return The source IPv4 address.
  * @return 0 if the source address cannot be determined.
  */
-unsigned long get_src_ip4_address_for_dst(unsigned long dst_ip4);
+IPaddr get_src_ip4_address_for_dst(IPaddr dst_ip4);
 
 class t_url {
 private:
@@ -164,12 +167,12 @@ public:
 
 	// ip address network order. Return 0 if address not found
 	// DNS A RR lookup
-	unsigned long get_n_ip(void) const;
+	IPNaddr get_n_ip(void) const;
 
 	// ip address host order. Return 0 if address not found
 	// DNS A RR lookup
-	unsigned long get_h_ip(void) const;
-	list<unsigned long> get_h_ip_all(void) const;
+	IPaddr get_h_ip(void) const;
+	list<IPaddr> get_h_ip_all(void) const;
 
 	// DNS A RR lookup
 	string get_ip(void) const; // ip address as string

--- a/src/stun/stun_transaction.cpp
+++ b/src/stun/stun_transaction.cpp
@@ -33,7 +33,7 @@ extern t_event_queue		*evq_sender;
 extern t_phone			*phone;
 
 
-bool get_stun_binding(t_user *user_config, unsigned short src_port, unsigned long &mapped_ip,
+bool get_stun_binding(t_user *user_config, unsigned short src_port, IPaddr &mapped_ip,
 	unsigned short &mapped_port, int &err_code, string &err_reason)
 {
 	list<t_ip_port> destinations = 

--- a/src/stun/stun_transaction.h
+++ b/src/stun/stun_transaction.h
@@ -25,6 +25,7 @@
 #include "transaction.h"
 #include "threads/mutex.h"
 #include "threads/thread.h"
+#include "sockets/ipaddr.h"
 #include "sockets/socket.h"
 #include "sockets/url.h"
 
@@ -32,7 +33,7 @@
 // Returns true on success. Returns false when the STUN server returned
 // an error. Throws an int exception (containing errno) when some
 // socket operation fails.
-bool get_stun_binding(t_user *user_config, unsigned short src_port, unsigned long &mapped_ip,
+bool get_stun_binding(t_user *user_config, unsigned short src_port, IPaddr &mapped_ip,
 	unsigned short &mapped_port, int &err_code, string &err_reason);
 	
 	


### PR DESCRIPTION
Any migration towards IPv6 (#6) will require identifying all IP
addresses currently represented as `unsigned long`.  To this end, we now
change their type to one of two newly-introduced `typedef`s:

 - `IPaddr` for IPv4 addresses in host byte order
 - `IPNaddr` for IPv4 addresses in network byte order

(This also happens to fix a few instances where `unsigned int` was
erroneously used.)