### PR TITLE
warnings: Add limit on hour count in timer2str() [-Wformat-truncation]

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -180,7 +180,7 @@ string timer2str(unsigned long seconds) {
 	s = remainder % 60;
 	
 	char buf[16];
-	snprintf(buf, 16, "%01lu:%02lu:%02lu", h, m, s);
+	snprintf(buf, 16, "%01lu:%02lu:%02lu", (h % 1000), m, s);
 	return string(buf);
 }
 


### PR DESCRIPTION
As the C specification does not impose an upper bound on integer sizes,
there is no limit on the length of the string generated by `timer2str()`
either.  On a 64-bit system, a buffer overflow could (theoretically)
occur, given ridiculously large values.

This adds an (arbitrary) limit of 1000 hours, corresponding to a
duration of over a month, which should be more than sufficient.