### PR TITLE
Display any provided Reason header when receiving a BYE or CANCEL

### DIFF
--- a/src/dialog.cpp
+++ b/src/dialog.cpp
@@ -334,7 +334,8 @@ void t_dialog::state_w4answer(t_request *r, t_tuid tuid, t_tid tid) {
 		MEMMAN_DELETE(resp);
 		delete resp;
 
-		ui->cb_call_cancelled(line->get_line_number());
+		ui->cb_call_cancelled(line->get_line_number(),
+				r->hdr_reason.get_display_text());
 		state = DS_TERMINATED;
 		break;
 	case BYE:
@@ -358,7 +359,8 @@ void t_dialog::state_w4answer(t_request *r, t_tuid tuid, t_tid tid) {
 		MEMMAN_DELETE(resp);
 		delete resp;
 
-		ui->cb_far_end_hung_up(line->get_line_number());
+		ui->cb_far_end_hung_up(line->get_line_number(),
+				r->hdr_reason.get_display_text());
 		state = DS_TERMINATED;
 		break;
 	case PRACK:
@@ -543,7 +545,8 @@ void t_dialog::state_w4ack(t_request *r, t_tuid tuid, t_tid tid) {
 		}
 
 		if (end_after_ack) {
-			ui->cb_far_end_hung_up(line->get_line_number());
+			ui->cb_far_end_hung_up(line->get_line_number(),
+					end_after_ack_reason);
 			state = DS_TERMINATED;
 		} else {
 			state = DS_CONFIRMED;
@@ -570,6 +573,7 @@ void t_dialog::state_w4ack(t_request *r, t_tuid tuid, t_tid tid) {
 		// The session will be ended when an ACK has been
 		// received.
 		end_after_ack = true;
+		end_after_ack_reason = r->hdr_reason.get_display_text();
 		break;
 	case PRACK:
 		// RFC 3262 3
@@ -644,7 +648,8 @@ void t_dialog::state_w4ack_re_invite(t_request *r, t_tuid tuid, t_tid tid) {
 		}
 
 		if (end_after_ack) {
-			ui->cb_far_end_hung_up(line->get_line_number());
+			ui->cb_far_end_hung_up(line->get_line_number(),
+					end_after_ack_reason);
 			state = DS_TERMINATED;
 		} else {
 			state = DS_CONFIRMED;
@@ -672,6 +677,7 @@ void t_dialog::state_w4ack_re_invite(t_request *r, t_tuid tuid, t_tid tid) {
 		// The session will be ended when an ACK has been
 		// received.
 		end_after_ack = true;
+		end_after_ack_reason = r->hdr_reason.get_display_text();
 		break;
 	default:
 		// ACK has not been received. Handle other incoming request
@@ -753,7 +759,8 @@ void t_dialog::state_w4re_invite_resp(t_request *r, t_tuid tuid, t_tid tid) {
 		
 		MEMMAN_DELETE(resp);
 		delete resp;
-		ui->cb_far_end_hung_up(line->get_line_number());
+		ui->cb_far_end_hung_up(line->get_line_number(),
+				r->hdr_reason.get_display_text());
 		line->call_hist_record.end_call(true);
 
 		if (!sub_refer) {
@@ -817,7 +824,8 @@ void t_dialog::state_confirmed(t_request *r, t_tuid tuid, t_tid tid) {
 		
 		MEMMAN_DELETE(resp);
 		delete resp;
-		ui->cb_far_end_hung_up(line->get_line_number());
+		ui->cb_far_end_hung_up(line->get_line_number(),
+				r->hdr_reason.get_display_text());
 		line->call_hist_record.end_call(true);
 
 		if (!sub_refer) {
@@ -2378,6 +2386,7 @@ t_dialog::t_dialog(t_line *_line) :
 
 	request_cancelled = false;
 	end_after_ack = false;
+	end_after_ack_reason = "";
 	end_after_2xx_invite = false;
 	answer_after_prack = false;
 	ringing_received = false;

--- a/src/dialog.h
+++ b/src/dialog.h
@@ -248,6 +248,8 @@ protected:
 
 	/** Indication that the dialog must be terminated after ACK. */
 	bool end_after_ack;
+	/** Optional reason provided by the far end. */
+	std::string end_after_ack_reason;
 
 	/**
 	 * Indication that the user wants to answer the call.

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1160,7 +1160,7 @@ void t_gui::cb_incoming_call(t_user *user_config, int line, const t_request *r) 
 	unlock();
 }
 
-void t_gui::cb_call_cancelled(int line) {
+void t_gui::cb_call_cancelled(int line, const std::string &reason) {
 	if (line >= NUM_USER_LINES) return;
 	
 	lock();
@@ -1170,12 +1170,17 @@ void t_gui::cb_call_cancelled(int line) {
 	s = qApp->translate("GUI", "Line %1: far end cancelled call.").arg(line + 1);
 	emit mw_display(s);
 	
+	if (!reason.empty()) {
+		s = reason.c_str();
+		emit mw_display(s);
+	}
+
 	cb_stop_call_notification(line);
 	
 	unlock();
 }
 
-void t_gui::cb_far_end_hung_up(int line) {
+void t_gui::cb_far_end_hung_up(int line, const std::string &reason) {
 	if (line >= NUM_USER_LINES) return;
 	
 	lock();
@@ -1184,6 +1189,11 @@ void t_gui::cb_far_end_hung_up(int line) {
 	emit mw_display_header();
 	s = qApp->translate("GUI", "Line %1: far end released call.").arg(line + 1);
 	emit mw_display(s);
+
+	if (!reason.empty()) {
+		s = reason.c_str();
+		emit mw_display(s);
+	}
 
 	cb_stop_call_notification(line);
 	

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -213,8 +213,8 @@ public:
 	
 	// Call back functions
 	void cb_incoming_call(t_user *user_config, int line, const t_request *r);
-	void cb_call_cancelled(int line);
-	void cb_far_end_hung_up(int line);
+	void cb_call_cancelled(int line, const std::string &reason);
+	void cb_far_end_hung_up(int line, const std::string &reason);
 	void cb_answer_timeout(int line);
 	void cb_sdp_answer_not_supported(int line, const string &reason);
 	void cb_sdp_answer_missing(int line);

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -47,6 +47,7 @@ set(LIBTWINKLE_PARSER-SRCS
 	hdr_proxy_authorization.cpp
 	hdr_proxy_require.cpp
 	hdr_rack.cpp
+	hdr_reason.cpp
 	hdr_record_route.cpp
 	hdr_refer_sub.cpp
 	hdr_refer_to.cpp

--- a/src/parser/hdr_reason.cpp
+++ b/src/parser/hdr_reason.cpp
@@ -1,0 +1,121 @@
+/*
+    Copyright (C) 2005-2009  Michel de Boer <michel@twinklephone.com>
+    Copyright (C) 2022       Frédéric Brière <fbriere@fbriere.net>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "hdr_reason.h"
+#include "parse_ctrl.h"
+#include "util.h"
+
+
+t_reason::t_reason(const std::string &_protocol) :
+	protocol(_protocol)
+{
+}
+
+void t_reason::set_cause(const std::string &_cause) {
+	cause = _cause;
+}
+
+void t_reason::set_text(const std::string &_text) {
+	text = _text;
+}
+
+void t_reason::add_extension(const t_parameter &p) {
+	extensions.push_back(p);
+}
+
+std::string t_reason::encode(void) const {
+	std::string s;
+
+	s = protocol;
+
+	if (!cause.empty()) {
+		s += ";cause=";
+		s += cause;
+	}
+
+	if (!text.empty()) {
+		s += ";text=\"";
+		s += text;
+		s += "\"";
+	}
+
+	s += param_list2str(extensions);
+
+	return s;
+}
+
+
+t_hdr_reason::t_hdr_reason() : t_header("Reason") {}
+
+void t_hdr_reason::add_reason(const t_reason &reason) {
+	populated = true;
+	reason_list.push_back(reason);
+}
+
+std::string t_hdr_reason::get_display_text() const {
+	for (const auto &r : reason_list) {
+		if (r.protocol == "SIP") {
+			std::vector<std::string> elems;
+
+			if (!r.cause.empty()) {
+				elems.push_back(r.cause);
+			}
+			if (!r.text.empty()) {
+				elems.push_back(r.text);
+			}
+
+			if (!elems.empty()) {
+				return join_strings(elems, " ");
+			}
+		}
+	}
+
+	return {};
+}
+
+std::string t_hdr_reason::encode(void) const {
+	return (t_parser::multi_values_as_list ?
+			t_header::encode() : encode_multi_header());
+}
+
+std::string t_hdr_reason::encode_multi_header(void) const {
+	std::string s;
+
+	if (!populated) return s;
+
+	for (const auto &r : reason_list) {
+		s += header_name;
+		s += ": ";
+		s += r.encode();
+		s += CRLF;
+	}
+
+	return s;
+}
+
+std::string t_hdr_reason::encode_value(void) const {
+	if (!populated) return {};
+
+	std::vector<std::string> encoded_values;
+
+	for (const auto &r : reason_list) {
+		encoded_values.push_back(r.encode());
+	}
+
+	return join_strings(encoded_values, ",");
+}

--- a/src/parser/hdr_reason.h
+++ b/src/parser/hdr_reason.h
@@ -1,0 +1,64 @@
+/*
+    Copyright (C) 2005-2009  Michel de Boer <michel@twinklephone.com>
+    Copyright (C) 2022       Frédéric Brière <fbriere@fbriere.net>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+// Reason header (RFC 3326)
+
+#ifndef _HDR_REASON_H
+#define _HDR_REASON_H
+
+#include <list>
+#include <string>
+
+#include "header.h"
+#include "parameter.h"
+
+
+class t_reason {
+public:
+	std::string       	protocol;	// "SIP", "Q.850" or other
+	std::string       	cause;		// For SIP, status code
+	std::string       	text;		// Reason text
+	std::list<t_parameter>	extensions;
+
+	t_reason(const std::string &_protocol);
+
+	void set_cause(const std::string &_cause);
+	void set_text(const std::string &_text);
+	void add_extension(const t_parameter &p);
+
+	string encode(void) const;
+};
+
+class t_hdr_reason : public t_header {
+public:
+	std::list<t_reason> reason_list;
+
+	t_hdr_reason();
+
+	void add_reason(const t_reason &reason);
+
+	// Returns a (possibly empty) string that can be displayed as an
+	// explanation to the user
+	std::string get_display_text() const;
+
+	string encode(void) const;
+	string encode_multi_header(void) const;
+	string encode_value(void) const;
+};
+
+#endif

--- a/src/parser/parser.yxx
+++ b/src/parser/parser.yxx
@@ -64,6 +64,7 @@ void yyerror(const char *s);
 	t_contact_param		*yyt_contact;
 	t_error_param		*yyt_error_param;
 	t_identity		*yyt_from_addr;
+	t_reason		*yyt_reason;
 	t_route			*yyt_route;
 	t_server		*yyt_server;
 	t_via			*yyt_via;
@@ -132,6 +133,7 @@ void yyerror(const char *s);
 %token			T_HDR_RACK
 %token			T_HDR_RECORD_ROUTE
 %token			T_HDR_SERVICE_ROUTE
+%token			T_HDR_REASON
 %token			T_HDR_REFER_SUB
 %token			T_HDR_REFER_TO
 %token			T_HDR_REFERRED_BY
@@ -206,6 +208,7 @@ void yyerror(const char *s);
 %type <yyt_str>		parameter_val
 %type <yyt_params>	parameters
 %type <yyt_float>	q_factor
+%type <yyt_reason>	reason_param
 %type <yyt_route>	rec_route
 %type <yyt_via>		sent_protocol
 %type <yyt_server>	server
@@ -239,6 +242,7 @@ void yyerror(const char *s);
 %destructor { MEMMAN_DELETE($$); delete $$; }	parameter
 %destructor { MEMMAN_DELETE($$); delete $$; }	parameter_val
 %destructor { MEMMAN_DELETE($$); delete $$; }	parameters
+%destructor { MEMMAN_DELETE($$); delete $$; }	reason_param
 %destructor { MEMMAN_DELETE($$); delete $$; }	rec_route
 %destructor { MEMMAN_DELETE($$); delete $$; }	sent_protocol
 %destructor { MEMMAN_DELETE($$); delete $$; }	server
@@ -361,6 +365,7 @@ header:		  hd_accept hdr_accept T_CRLF
 		| hd_proxy_authorization hdr_proxy_authorization T_CRLF
 		| hd_proxy_require hdr_proxy_require T_CRLF
 		| hd_rack hdr_rack T_CRLF
+		| hd_reason hdr_reason T_CRLF
 		| hd_record_route hdr_record_route T_CRLF
 		| hd_refer_sub hdr_refer_sub T_CRLF
 		| hd_refer_to hdr_refer_to T_CRLF
@@ -463,6 +468,8 @@ header:		  hd_accept hdr_accept T_CRLF
 			{ PARSE_ERROR("Proxy-Require"); }
 		| hd_rack error T_CRLF
 			{ PARSE_ERROR("RAck"); }
+		| hd_reason error T_CRLF
+			{ PARSE_ERROR("Reason"); }
 		| hd_record_route error T_CRLF
 			{ PARSE_ERROR("Record-Route"); }
 		| hd_refer_sub error T_CRLF
@@ -597,6 +604,8 @@ hd_proxy_authorization:	T_HDR_PROXY_AUTHORIZATION ':' { CTXT_AUTH_SCHEME; }
 hd_proxy_require:	T_HDR_PROXY_REQUIRE ':'
 ;
 hd_rack:		T_HDR_RACK ':' { CTXT_NUM; }
+;
+hd_reason:		T_HDR_REASON ':'
 ;
 hd_record_route:	T_HDR_RECORD_ROUTE ':' { CTXT_URI; }
 ;
@@ -1073,6 +1082,29 @@ hdr_proxy_require:   T_TOKEN {
 		   | hdr_proxy_require ',' T_TOKEN {
 			MSG->hdr_proxy_require.add_feature(tolower(*$3));
 			MEMMAN_DELETE($3); delete $3; }
+;
+
+hdr_reason:	  reason_param {
+			MSG->hdr_reason.add_reason(*$1);
+			MEMMAN_DELETE($1); delete $1; }
+		| hdr_reason ',' reason_param {
+			MSG->hdr_reason.add_reason(*$3);
+			MEMMAN_DELETE($3); delete $3; }
+;
+
+reason_param:	  T_TOKEN parameters {
+			$$ = new t_reason(*$1);
+			MEMMAN_NEW($$);
+			for (const auto &param : *$2) {
+				if (param.name == "cause") {
+					$$->set_cause(param.value);
+				} else if (param.name == "text") {
+					$$->set_text(param.value);
+				} else {
+					$$->add_extension(param);
+				}
+			}
+			MEMMAN_DELETE($2); delete $2; }
 ;
 
 hdr_record_route:   rec_route {

--- a/src/parser/scanner.lxx
+++ b/src/parser/scanner.lxx
@@ -108,6 +108,7 @@ WORD_SYM	[[:alnum:]\-\.!%\*_\+\`\'~\(\)<>:\\\"\/\[\]\?\{\}]
 ^(?i:Proxy-Authorization)	{ return T_HDR_PROXY_AUTHORIZATION; }
 ^(?i:Proxy-Require)		{ return T_HDR_PROXY_REQUIRE; }
 ^(?i:RAck)			{ return T_HDR_RACK; }
+^(?i:Reason)			{ return T_HDR_REASON; }
 ^(?i:Record-Route)		{ return T_HDR_RECORD_ROUTE; }
 ^(?i:Service-Route)		{ return T_HDR_SERVICE_ROUTE; }
 ^(?i:Refer-Sub)			{ return T_HDR_REFER_SUB; }

--- a/src/parser/sip_message.cpp
+++ b/src/parser/sip_message.cpp
@@ -77,6 +77,7 @@ t_sip_message::t_sip_message(const t_sip_message& m) :
 		hdr_proxy_authorization(m.hdr_proxy_authorization),
 		hdr_proxy_require(m.hdr_proxy_require),
 		hdr_rack(m.hdr_rack),
+		hdr_reason(m.hdr_reason),
 		hdr_record_route(m.hdr_record_route),
 		hdr_refer_sub(m.hdr_refer_sub),
 		hdr_refer_to(m.hdr_refer_to),
@@ -239,6 +240,7 @@ string t_sip_message::encode(bool add_content_length) {
 	s += hdr_organization.encode();
 	s += hdr_priority.encode();
 	s += hdr_rack.encode();
+	s += hdr_reason.encode();
 	s += hdr_refer_sub.encode();
 	s += hdr_refer_to.encode();
 	s += hdr_referred_by.encode();
@@ -348,6 +350,7 @@ list<string> t_sip_message::encode_env(void) {
 	l.push_back(hdr_organization.encode_env());
 	l.push_back(hdr_priority.encode_env());
 	l.push_back(hdr_rack.encode_env());
+	l.push_back(hdr_reason.encode_env());
 	l.push_back(hdr_refer_sub.encode_env());
 	l.push_back(hdr_refer_to.encode_env());
 	l.push_back(hdr_referred_by.encode_env());

--- a/src/parser/sip_message.h
+++ b/src/parser/sip_message.h
@@ -59,6 +59,7 @@
 #include "hdr_proxy_authorization.h"
 #include "hdr_proxy_require.h"
 #include "hdr_rack.h"
+#include "hdr_reason.h"
 #include "hdr_record_route.h"
 #include "hdr_refer_sub.h"
 #include "hdr_refer_to.h"
@@ -157,6 +158,7 @@ public:
 	t_hdr_proxy_authorization hdr_proxy_authorization;
 	t_hdr_proxy_require	hdr_proxy_require;
 	t_hdr_rack		hdr_rack;
+	t_hdr_reason		hdr_reason;
 	t_hdr_record_route	hdr_record_route;
 	t_hdr_refer_sub		hdr_refer_sub;
 	t_hdr_refer_to		hdr_refer_to;

--- a/src/userintf.cpp
+++ b/src/userintf.cpp
@@ -2496,24 +2496,30 @@ void t_userintf::cb_incoming_call(t_user *user_config, int line, const t_request
 	cb_notify_call(line, from_party);
 }
 
-void t_userintf::cb_call_cancelled(int line) {
+void t_userintf::cb_call_cancelled(int line, const std::string &reason) {
 	if (line >= NUM_USER_LINES) return;
 	
 	cout << endl;
 	cout << "Line " << line + 1 << ": ";
 	cout << "far end cancelled call.\n";
+	if (!reason.empty()) {
+		cout << reason << endl;
+	}
 	cout << endl;
 	cout.flush();
 
 	cb_stop_call_notification(line);
 }
 
-void t_userintf::cb_far_end_hung_up(int line) {
+void t_userintf::cb_far_end_hung_up(int line, const std::string &reason) {
 	if (line >= NUM_USER_LINES) return;
 	
 	cout << endl;
 	cout << "Line " << line + 1 << ": ";
 	cout << "far end ended call.\n";
+	if (!reason.empty()) {
+		cout << reason << endl;
+	}
 	cout << endl;
 	cout.flush();
 

--- a/src/userintf.h
+++ b/src/userintf.h
@@ -229,8 +229,8 @@ public:
 
         // Call back functions
         virtual void cb_incoming_call(t_user *user_config, int line, const t_request *r);
-        virtual void cb_call_cancelled(int line);
-        virtual void cb_far_end_hung_up(int line);
+        virtual void cb_call_cancelled(int line, const std::string &reason);
+        virtual void cb_far_end_hung_up(int line, const std::string &reason);
         virtual void cb_answer_timeout(int line);
         virtual void cb_sdp_answer_not_supported(int line, const string &reason);
         virtual void cb_sdp_answer_missing(int line);


### PR DESCRIPTION
[RFC 3326](https://datatracker.ietf.org/doc/html/rfc3326) defines a `Reason` header field which can be added to a request
in order to provide some explanation for why that request was issued.
It is mostly useful for `BYE` and `CANCEL` requests, so that the UA can
explain why a call or `INVITE` was terminated.

While we don't bother generating such headers (yet), we should at least
be kind enough to display those which we receive.