### PR TITLE
Skip C++11 regular expressions check when cross-compiling

### DIFF
--- a/cmake/CheckCXX11Regex.cmake
+++ b/cmake/CheckCXX11Regex.cmake
@@ -10,6 +10,16 @@ include(CMakePushCheckState)
 include(CheckCXXSourceRuns)
 
 function(check_cxx11_regex result_var)
+	# When cross-compiling, check_cxx_source_runs() below will cause the
+	# build to fail.  Since libstdc++ 4.8 is pretty much obsolete by now,
+	# we may as well assume that everything is working fine.
+	if(CMAKE_CROSSCOMPILING)
+		message(STATUS "Skipping C++11 regular expressions check due to cross-compilation")
+		# Returning a true value that we could recognize if needed
+		set(${result_var} 42 PARENT_SCOPE)
+		return()
+	endif()
+
 	cmake_push_check_state()
 	set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
 


### PR DESCRIPTION
The C++11 regular expressions check added in #117 involves compiling and
running a test program.  When cross-compiling, this is no longer
possible, and calling `check_cxx_source_runs()` will cause the build to
fail.

Since libstdc++ 4.8 is pretty much obsolete by now and can only be found
in old enterprise LTS releases¹ that are near their end-of-life, we may
as well skip that check when cross-compiling and simply assume that
everything is working fine.

 ¹ Distribution releases still using libstdc++ 4.8 as of today:
- Ubuntu 14.04 LTS (Trusty Tahr)
- Red Hat Enterprise Linux 7
- SUSE Linux Enterprise Server 12