### PR TITLE
Avoid segfaulting if `QQuickView::setSource()` fails to load a component

### DIFF
--- a/src/gui/incoming_call_popup.cpp
+++ b/src/gui/incoming_call_popup.cpp
@@ -15,6 +15,10 @@ IncomingCallPopup::IncomingCallPopup(QObject *parent) : QObject(parent)
 	m_view->rootContext()->setContextProperty("viewerWidget", m_view);
 	m_view->setSource(QUrl("qrc:/qml/incoming_call.qml"));
 
+	if (!m_view->rootObject()) {
+		throw std::runtime_error("Could not load incoming_call.qml");
+	}
+
     // Place into the middle of the screen
 	positionWindow();
 

--- a/src/gui/osd.cpp
+++ b/src/gui/osd.cpp
@@ -19,6 +19,10 @@ OSD::OSD(QObject* parent)
 	m_view->rootContext()->setContextProperty("viewerWidget", m_view);
 	m_view->setSource(QUrl("qrc:/qml/osd.qml"));
 
+	if (!m_view->rootObject()) {
+		throw std::runtime_error("Could not load osd.qml");
+	}
+
 	positionWindow();
 
 	QObject* buttonHangup;


### PR DESCRIPTION
If `QQuickView::setSource()` fails to load a QML component for any
reason, `rootObject()` will then return a null pointer, which will cause
segfaults if not accounted for.