### PR TITLE
Fix `t_gui::cb_message_request()` using a `QTimer` on a non-Qt thread

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -2654,6 +2654,17 @@ void t_gui::cb_mwi_terminated(t_user *user_config, const string &reason) {
 }
 
 bool t_gui::cb_message_request(t_user *user_config, t_request *r) {	
+	bool retval;
+	QMetaObject::invokeMethod(this, "do_cb_message_request",
+				  Qt::BlockingQueuedConnection,
+				  Q_RETURN_ARG(bool, retval),
+				  Q_ARG(t_user*, user_config),
+				  Q_ARG(t_request*, r));
+
+	return retval;
+}
+
+bool t_gui::do_cb_message_request(t_user *user_config, t_request *r) {
 	string text;
 	im::t_text_format text_format = im::TXT_PLAIN;
 	bool attachment = false;

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -454,6 +454,7 @@ private slots:
 			const string &refer_to_display,
 			const string &referred_by_uri_str,
 			const string &referred_by_display);
+	bool do_cb_message_request(t_user *user_config, t_request *r);
     void do_cb_register_inprog(t_user *user_config, t_register_type register_type);
 };
 


### PR DESCRIPTION
Qt only allows using `QTimer` on threads started with `QThread`, but
`t_gui::cb_message_request()`, which is running on the `thr_phone_uas`
(non-Qt) thread, is currently creating one via `addMessageSession()`.
This results in Twinkle glitching out after spewing out a stream of
warnings upon receiving a message:

  QObject::startTimer: Timers can only be used with threads started with QThread
  QObject::installEventFilter(): Cannot filter events for objects in a different thread.
  QObject::installEventFilter(): Cannot filter events for objects in a different thread.
  QObject::installEventFilter(): Cannot filter events for objects in a different thread.