### PR TITLE
Properly set up URL of a message attachment

### DIFF
--- a/src/gui/messageform.cpp
+++ b/src/gui/messageform.cpp
@@ -344,7 +344,7 @@ void MessageForm::addMessage(const im::t_msg &msg, const QString &name)
 	if (msg.has_attachment) {
 		s += "<br>";
 		s += "<a href=\"";
-		s += msg.attachment_filename.c_str();
+		s += QUrl::fromLocalFile(msg.attachment_filename.c_str()).toString();
 		s += "\">";
 		
 		bool show_attachment_inline = false;


### PR DESCRIPTION
The URL of a message attachment must use the `file:` scheme; otherwise,
the subsequent call to `toLocalFile()` will return an empty string.