### PR TITLE
qt5+: Replace `qSort()` with `std::sort()`

### DIFF
--- a/src/gui/addresstablemodel.cpp
+++ b/src/gui/addresstablemodel.cpp
@@ -17,6 +17,7 @@
 
 #include "addresstablemodel.h"
 #include <QtDebug>
+#include <algorithm>
 
 AddressTableModel::AddressTableModel(QObject *parent, const list<t_address_card>& data)
 	: QAbstractTableModel(parent)
@@ -97,7 +98,7 @@ void AddressTableModel::modifyAddress(int index, const t_address_card& card)
 
 void AddressTableModel::sort(int column, Qt::SortOrder order)
 {
-	qSort(m_data.begin(), m_data.end(), [=](const t_address_card& a1, const t_address_card& a2) -> bool {
+	std::sort(m_data.begin(), m_data.end(), [=](const t_address_card& a1, const t_address_card& a2) -> bool {
 		bool retval = false;
 
 		switch (column)


### PR DESCRIPTION
`qSort()` (along with a good portion of `QtAlgorithms`) was deprecated
in Qt 5.2, in favor of using STL algorithms instead.

Note that `std::sort` is not an *exact* drop-in replacement for `qSort`,
due to the following differences:

- `qSort` can take a Qt container as argument
- `qSort` will automatically use `qLess<T>` if defined
- `std::sort` requires the comparison functor to honour Strict Weak
  Ordering

The first two points don't apply to us; we never call `qSort` with a
container, nor do we ever specialize `qLess<T>` anywhere.

As for the last point, since `AddressTableModel::sort()` eventually
delegates its job to the `<` and `>` operators (defaulting to `false`),
it can never return `true` for both a comparison and its opposite, thus
satisfying Strict Weak Ordering.