### PR TITLE
qt5+: Switch from `QRegExp` to `QRegularExpression`

### DIFF
--- a/src/gui/diamondcardprofileform.cpp
+++ b/src/gui/diamondcardprofileform.cpp
@@ -19,9 +19,9 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QValidator>
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 #include "gui.h"
 #include "diamondcard.h"
 #include "getprofilenameform.h"
@@ -66,9 +66,9 @@ void DiamondcardProfileForm::init()
 	user_config = NULL;
 	destroy_user_config = false;
 	
-	QRegExp rxNoSpace("\\S*");
-	accountIdLineEdit->setValidator(new QRegExpValidator(rxNoSpace, this));
-	pinCodeLineEdit->setValidator(new QRegExpValidator(rxNoSpace, this));
+	QRegularExpression rxNoSpace("\\S*");
+	accountIdLineEdit->setValidator(new QRegularExpressionValidator(rxNoSpace, this));
+	pinCodeLineEdit->setValidator(new QRegularExpressionValidator(rxNoSpace, this));
 }
 
 void DiamondcardProfileForm::destroy()

--- a/src/gui/getaddressform.cpp
+++ b/src/gui/getaddressform.cpp
@@ -17,7 +17,6 @@
 
 #include "getaddressform.h"
 #include <QMessageBox>
-#include <QRegExp>
 #include "sys_settings.h"
 #include "gui.h"
 #include "address_book.h"

--- a/src/gui/getprofilenameform.cpp
+++ b/src/gui/getprofilenameform.cpp
@@ -1,7 +1,7 @@
 #include "getprofilenameform.h"
 #include <QDir>
 #include <QMessageBox>
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 #include "user.h"
 #include "protocol.h"
 
@@ -30,11 +30,11 @@ GetProfileNameForm::~GetProfileNameForm()
 void GetProfileNameForm::init()
 {
 	// Letters, digits, underscore, minus, "@" and period
-	QRegExp rxFilenameChars("[\\w\\-@\\.]*");
+	QRegularExpression rxFilenameChars("[\\w\\-@\\.]*");
 
 	// Set validators
 	// USER
-	profileLineEdit->setValidator(new QRegExpValidator(rxFilenameChars, this));
+	profileLineEdit->setValidator(new QRegularExpressionValidator(rxFilenameChars, this));
 
 	// Focus seems to default to OK button, despite tab order
 	profileLineEdit->setFocus();
@@ -47,8 +47,8 @@ void GetProfileNameForm::validate()
 	if (profileName.isEmpty()) return;
 
 	// Check for anything that was let through by the validator
-	QRegExp rxFilename("^[\\w\\-][\\w\\-@\\.]*$");
-	if (!rxFilename.exactMatch(profileName)) {
+	QRegularExpression rxFilename("^[\\w\\-][\\w\\-@\\.]*$");
+	if (!rxFilename.match(profileName).hasMatch()) {
 		QMessageBox::critical(this, PRODUCT_NAME,
 			tr("Invalid profile name: %1").arg(profileName)
 			// While this would be better suited as informativeText,

--- a/src/gui/inviteform.cpp
+++ b/src/gui/inviteform.cpp
@@ -5,9 +5,9 @@
 #include "util.h"
 #include "audits/memman.h"
 #include "sys_settings.h"
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QValidator>
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 
 /*
     Copyright (C) 2005-2009  Michel de Boer <michel@twinklephone.com>
@@ -46,8 +46,8 @@ void InviteForm::init()
 	setDisabledIcon(addressToolButton, ":/icons/images/kontact_contacts-disabled.png");
 	
 	// A QComboBox accepts a new line through copy/paste.
-	QRegExp rxNoNewLine("[^\\n\\r]*");
-	inviteComboBox->setValidator(new QRegExpValidator(rxNoNewLine, this));
+	QRegularExpression rxNoNewLine("[^\\n\\r]*");
+	inviteComboBox->setValidator(new QRegularExpressionValidator(rxNoNewLine, this));
 }
 
 void InviteForm::destroy()

--- a/src/gui/mphoneform.cpp
+++ b/src/gui/mphoneform.cpp
@@ -51,10 +51,10 @@
 #include "util.h"
 #include <QTimer>
 #include <QCursor>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QValidator>
 #include <QSettings>
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 #include "buddyform.h"
 #include "diamondcardprofileform.h"
 #include "osd.h"
@@ -194,8 +194,8 @@ void MphoneForm::init()
 	}
 	
 	// A QComboBox accepts a new line through copy/paste.
-	QRegExp rxNoNewLine("[^\\n\\r]*");
-	callComboBox->setValidator(new QRegExpValidator(rxNoNewLine, this));
+	QRegularExpression rxNoNewLine("[^\\n\\r]*");
+	callComboBox->setValidator(new QRegularExpressionValidator(rxNoNewLine, this));
 	
 	if (sys_config->get_gui_use_systray()) {
 		// Create system tray icon

--- a/src/gui/numberconversionform.cpp
+++ b/src/gui/numberconversionform.cpp
@@ -1,6 +1,6 @@
 #include "numberconversionform.h"
 
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 #include "gui.h"
 
 /*
@@ -26,10 +26,10 @@ NumberConversionForm::~NumberConversionForm()
 
 void NumberConversionForm::init()
 {
-	QRegExp rxNoAtSign("[^@]*");
+	QRegularExpression rxNoAtSign("[^@]*");
 
-	exprLineEdit->setValidator(new QRegExpValidator(rxNoAtSign, this));
-	replaceLineEdit->setValidator(new QRegExpValidator(rxNoAtSign, this));
+	exprLineEdit->setValidator(new QRegularExpressionValidator(rxNoAtSign, this));
+	replaceLineEdit->setValidator(new QRegularExpressionValidator(rxNoAtSign, this));
 }
 
 int NumberConversionForm::exec(QString &expr, QString &replace)

--- a/src/gui/syssettingsform.cpp
+++ b/src/gui/syssettingsform.cpp
@@ -28,9 +28,9 @@
 #include <QFileDialog>
 #include <QFileInfo>
 #include "twinkle_config.h"
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QValidator>
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 #include "syssettingsform.h"
 /*
  *  Constructs a SysSettingsForm as a child of 'parent', with the
@@ -85,9 +85,9 @@ void SysSettingsForm::init()
             QIcon::Disabled);
     openRingbackToolButton->setIcon(i);
 	
-	QRegExp rxNumber("[0-9]+");
-	maxUdpSizeLineEdit->setValidator(new QRegExpValidator(rxNumber, this));
-	maxTcpSizeLineEdit->setValidator(new QRegExpValidator(rxNumber, this));
+	QRegularExpression rxNumber("[0-9]+");
+	maxUdpSizeLineEdit->setValidator(new QRegularExpressionValidator(rxNumber, this));
+	maxTcpSizeLineEdit->setValidator(new QRegularExpressionValidator(rxNumber, this));
 }
 
 void SysSettingsForm::showCategory( int index )

--- a/src/gui/userprofileform.cpp
+++ b/src/gui/userprofileform.cpp
@@ -20,7 +20,7 @@
 #include <QLabel>
 #include <QComboBox>
 #include <QSpinBox>
-#include <QRegExp>
+#include <QRegularExpression>
 #include "sdp/sdp.h"
 #include <QValidator>
 #include "protocol.h"
@@ -31,7 +31,7 @@
 #include <QStringList>
 #include "twinkle_config.h"
 #include <QListWidget>
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 #include "numberconversionform.h"
 #include "util.h"
 #include "userprofileform.h"
@@ -147,31 +147,31 @@ void UserProfileForm::languageChange()
 
 void UserProfileForm::init()
 {
-	QRegExp rxNoSpace("\\S*");
-	QRegExp rxNoAtSign("[^@]*");
-	QRegExp rxQvalue("(0\\.[0-9]{0,3})|(1\\.0{0,3})");
-	QRegExp rxAkaOpValue("[a-zA-Z0-9]{0,32}");
-	QRegExp rxAkaAmfValue("[a-zA-Z0-9]{0,4}");
+	QRegularExpression rxNoSpace("\\S*");
+	QRegularExpression rxNoAtSign("[^@]*");
+	QRegularExpression rxQvalue("(0\\.[0-9]{0,3})|(1\\.0{0,3})");
+	QRegularExpression rxAkaOpValue("[a-zA-Z0-9]{0,32}");
+	QRegularExpression rxAkaAmfValue("[a-zA-Z0-9]{0,4}");
 	
 	// Set validators
 	// USER
-	domainLineEdit->setValidator(new QRegExpValidator(rxNoSpace, this));
-	authAkaOpLineEdit->setValidator(new QRegExpValidator(rxAkaOpValue, this));
-	authAkaAmfLineEdit->setValidator(new QRegExpValidator(rxAkaAmfValue, this));
+	domainLineEdit->setValidator(new QRegularExpressionValidator(rxNoSpace, this));
+	authAkaOpLineEdit->setValidator(new QRegularExpressionValidator(rxAkaOpValue, this));
+	authAkaAmfLineEdit->setValidator(new QRegularExpressionValidator(rxAkaAmfValue, this));
 	
 	// SIP SERVER
-	registrarLineEdit->setValidator(new QRegExpValidator(rxNoSpace, this));
-	regQvalueLineEdit->setValidator(new QRegExpValidator(rxQvalue, this));
-	proxyLineEdit->setValidator(new QRegExpValidator(rxNoSpace, this));
+	registrarLineEdit->setValidator(new QRegularExpressionValidator(rxNoSpace, this));
+	regQvalueLineEdit->setValidator(new QRegularExpressionValidator(rxQvalue, this));
+	proxyLineEdit->setValidator(new QRegularExpressionValidator(rxNoSpace, this));
 	
 	// Voice mail
-	mwiServerLineEdit->setValidator(new QRegExpValidator(rxNoSpace, this));
+	mwiServerLineEdit->setValidator(new QRegularExpressionValidator(rxNoSpace, this));
 	
 	// NAT
-	publicIPLineEdit->setValidator(new QRegExpValidator(rxNoSpace, this));
+	publicIPLineEdit->setValidator(new QRegularExpressionValidator(rxNoSpace, this));
 	
 	// Address format
-	testConversionLineEdit->setValidator(new QRegExpValidator(rxNoAtSign, this));
+	testConversionLineEdit->setValidator(new QRegularExpressionValidator(rxNoAtSign, this));
 	
 #ifndef HAVE_SPEEX
 	// Speex & (Speex) Preprocessing

--- a/src/gui/wizardform.cpp
+++ b/src/gui/wizardform.cpp
@@ -15,7 +15,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QLineEdit>
 #include <QLabel>
 #include <QValidator>
@@ -23,7 +23,7 @@
 #include <QTextStream>
 #include "gui.h"
 #include <QFile>
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 #include "wizardform.h"
 
 #define PROV_NONE	QT_TRANSLATE_NOOP("WizardForm", "None (direct IP to IP calls)")
@@ -70,13 +70,13 @@ void WizardForm::languageChange()
 
 void WizardForm::init()
 {
-	QRegExp rxNoSpace("\\S*");
+	QRegularExpression rxNoSpace("\\S*");
 	
 	// Set validators
-	usernameLineEdit->setValidator(new QRegExpValidator(rxNoSpace, this));
-	domainLineEdit->setValidator(new QRegExpValidator(rxNoSpace, this));
-	authNameLineEdit->setValidator(new QRegExpValidator(rxNoSpace, this));
-	proxyLineEdit->setValidator(new QRegExpValidator(rxNoSpace, this));
+	usernameLineEdit->setValidator(new QRegularExpressionValidator(rxNoSpace, this));
+	domainLineEdit->setValidator(new QRegularExpressionValidator(rxNoSpace, this));
+	authNameLineEdit->setValidator(new QRegularExpressionValidator(rxNoSpace, this));
+	proxyLineEdit->setValidator(new QRegularExpressionValidator(rxNoSpace, this));
 	
 	initProviders();
     serviceProviderComboBox->setCurrentIndex(serviceProviderComboBox->count() - 1);


### PR DESCRIPTION
`QRegularExpression` was introduced in Qt 5.0 as a successor to
`QRegExp`, and while it is still supported under Qt 6 (via
`Core5Compat`), the corresponding `QRegExpValidator` is not.  Hence,
migrating will be required before being able to port to Qt 6 (#297).

While `QRegularExpression` is not always a drop-in replacement for
`QRegExp` (see the documentation¹ for details), in our case, it is.  Our
use doesn't run into any of the situations listed in the documentation,
while our only instance of `exactMatch()` uses a pattern that is already
anchored.

 ¹ https://doc.qt.io/qt-5/qregularexpression.html#notes-for-qregexp-users