### PR TITLE
qt5+: Pass single `StandardButtons` arg. to `QMessageBox` funcs

### DIFF
--- a/src/gui/getaddressform.cpp
+++ b/src/gui/getaddressform.cpp
@@ -215,15 +215,10 @@ void GetAddressForm::deleteLocalAddress()
 
 	QString card_name = QString::fromStdString(card.get_display_name());
 	QString msg = tr("Are you sure you want to delete contact '%1' from the local address book?").arg(card_name);
-	QMessageBox *mb = new QMessageBox(tr("Delete contact"), msg,
-			QMessageBox::Warning,
-			QMessageBox::Yes,
-			QMessageBox::No,
-			QMessageBox::NoButton,
-			this);
-	MEMMAN_NEW(mb);
+	int button = QMessageBox::warning(this, tr("Delete contact"), msg,
+			QMessageBox::Yes | QMessageBox::No);
 
-	if (mb->exec() == QMessageBox::Yes) {
+	if (button == QMessageBox::Yes) {
 		if (ab_local->del_address(card)) {
 			m_model->removeAddress(sel[0].row());
 
@@ -233,9 +228,6 @@ void GetAddressForm::deleteLocalAddress()
 			}
 		}
 	}
-
-	MEMMAN_DELETE(mb);
-	delete mb;
 }
 
 void GetAddressForm::editLocalAddress()

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -2465,19 +2465,19 @@ bool t_gui::cb_ask_msg(QWidget *parent, const string &msg, t_msg_priority prio) 
 	switch (prio) {
 	case MSG_INFO:
 		button = QMessageBox::information(parent, PRODUCT_NAME, msg.c_str(),
-			QMessageBox::Yes,
-			QMessageBox::No | QMessageBox::Escape | QMessageBox::Default);
+			QMessageBox::Yes | QMessageBox::No,
+			QMessageBox::No /* default */);
 		break;
 	case MSG_WARNING:
 		button = QMessageBox::warning(parent, PRODUCT_NAME, msg.c_str(),
-			QMessageBox::Yes,
-			QMessageBox::No | QMessageBox::Escape | QMessageBox::Default);
+			QMessageBox::Yes | QMessageBox::No,
+			QMessageBox::No /* default */);
 		break;
 	case MSG_CRITICAL:
 	default:
 		button = QMessageBox::critical(parent, PRODUCT_NAME, msg.c_str(),
-			QMessageBox::Yes,
-			QMessageBox::No | QMessageBox::Escape | QMessageBox::Default);
+			QMessageBox::Yes | QMessageBox::No,
+			QMessageBox::No /* default */);
 		break;
 	}
 	

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -2319,16 +2319,9 @@ bool t_gui::do_cb_ask_user_to_redirect_invite(t_user *user_config, const t_url &
 	s.append(qApp->translate("GUI",
 		"If you don't want to be asked this anymore, then you must change "
 		"the settings in the SIP protocol section of the user profile."));
-	QMessageBox *mb = new QMessageBox(title, s,
-					  QMessageBox::Warning,
-					  QMessageBox::Yes,
-					  QMessageBox::No,
-					  QMessageBox::NoButton,
-					  mainWindow);
-	MEMMAN_NEW(mb);
-	bool permission = (mb->exec() == QMessageBox::Yes);
-	MEMMAN_DELETE(mb);
-	delete mb;
+	int button = QMessageBox::warning(mainWindow, title, s,
+			QMessageBox::Yes | QMessageBox::No);
+	bool permission = (button == QMessageBox::Yes);
 
 	return permission;
 }
@@ -2357,16 +2350,9 @@ bool t_gui::do_cb_ask_user_to_redirect_request(t_user *user_config, const t_url 
 	s.append(qApp->translate("GUI",
 		"If you don't want to be asked this anymore, then you must change "
 		"the settings in the SIP protocol section of the user profile."));
-	QMessageBox *mb = new QMessageBox(title, s,
-					  QMessageBox::Warning,
-					  QMessageBox::Yes,
-					  QMessageBox::No,
-					  QMessageBox::NoButton,
-					  mainWindow);
-	MEMMAN_NEW(mb);
-	bool permission = (mb->exec() == QMessageBox::Yes);
-	MEMMAN_DELETE(mb);
-	delete mb;
+	int button = QMessageBox::warning(mainWindow, title, s,
+			QMessageBox::Yes | QMessageBox::No);
+	bool permission = (button == QMessageBox::Yes);
 
 	return permission;
 }

--- a/src/gui/mphoneform.cpp
+++ b/src/gui/mphoneform.cpp
@@ -2297,10 +2297,9 @@ void MphoneForm::about()
 {
 	QString s = sys_config->about(true).c_str();
 	
-	QMessageBox mbAbout(PRODUCT_NAME, s.replace(' ', "&nbsp;"), 
-		    QMessageBox::Information, 
-		    QMessageBox::Ok | QMessageBox::Default,
-		    QMessageBox::NoButton, QMessageBox::NoButton);
+	QMessageBox mbAbout(QMessageBox::Information,
+			PRODUCT_NAME, s.replace(' ', "&nbsp;"),
+			QMessageBox::Ok);
 	mbAbout.setIconPixmap(QPixmap(":/icons/images/twinkle48.png"));
 	mbAbout.exec();
 }

--- a/src/gui/selectprofileform.cpp
+++ b/src/gui/selectprofileform.cpp
@@ -379,14 +379,9 @@ void SelectProfileForm::deleteProfile()
     QListWidgetItem *item = profileListView->currentItem();
 	QString profile = item->text();
 	QString msg = tr("Are you sure you want to delete profile '%1'?").arg(profile);
-	QMessageBox *mb = new QMessageBox(tr("Delete profile"), msg,
-			QMessageBox::Warning,
-			QMessageBox::Yes,
-			QMessageBox::No,
-			QMessageBox::NoButton,
-			this);
-	MEMMAN_NEW(mb);
-	if (mb->exec() == QMessageBox::Yes) {
+	int button = QMessageBox::warning(this, tr("Delete profile"), msg,
+			QMessageBox::Yes | QMessageBox::No);
+	if (button == QMessageBox::Yes) {
 		// Delete file
 		QDir d = QDir::home();
 		d.cd(USER_DIR);
@@ -443,9 +438,6 @@ void SelectProfileForm::deleteProfile()
 			}
 		}
 	}
-	
-	MEMMAN_DELETE(mb);
-	delete mb;
 }
 
 void SelectProfileForm::renameProfile()

--- a/src/gui/selectprofileform.cpp
+++ b/src/gui/selectprofileform.cpp
@@ -106,7 +106,7 @@ int SelectProfileForm::execForm()
 			"Before you can use Twinkle, you must create a user "\
 			"profile.<br>Click OK to create a profile.</html>"));
 		
-		int newProfileMethod = QMessageBox::question(this, PRODUCT_NAME, tr(
+		QMessageBox mb(QMessageBox::Question, PRODUCT_NAME, tr(
 			"<html>"\
 			"You can use the profile editor to create a profile. "\
 			"With the profile editor you can change many settings "\
@@ -121,23 +121,29 @@ int SelectProfileForm::execForm()
             "calls to regular and cell phones and send SMS messages.<br><br>")
 #endif
             + tr("Choose what method you wish to use.</html>"),
-			tr("&Wizard"), tr("&Profile editor")
+			QMessageBox::NoButton, this);
+		QPushButton *wizardButton = mb.addButton(
+				tr("&Wizard"),
+				QMessageBox::AcceptRole);
+		QPushButton *editorButton = mb.addButton(
+				tr("&Profile editor"),
+				QMessageBox::AcceptRole);
 #ifdef WITH_DIAMONDCARD
-			, tr("&Diamondcard")
+		QPushButton *diamondCardButton = mb.addButton(
+				tr("&Diamondcard"),
+				QMessageBox::AcceptRole);
 #endif
-			);
+		mb.exec();
 		
-		switch (newProfileMethod) {
-		case 0:
+		if (mb.clickedButton() == wizardButton) {
 			wizardProfile(true);
-			break;
-		case 1:
+		} else if (mb.clickedButton() == editorButton) {
 			newProfile(true);
-			break;
-		case 2:
+#ifdef WITH_DIAMONDCARD
+		} else if (mb.clickedButton() == diamondCardButton) {
 			diamondcardProfile(true);
-			break;
-		default:
+#endif
+		} else {
 			return QDialog::Rejected;
 		}
 		


### PR DESCRIPTION
Invoking `QMessageBox` functions with separate `button0`, `button1`, ...
arguments was deprecated in Qt 4; all button specifications are now
passed within a single `QMessageBox::StandardButtons` argument.

Since the old form is not supported by Qt 6, these changes are required before porting can be completed (#297).