### PR TITLE
Explicitly declare the `environ` variable

### DIFF
--- a/src/call_script.cpp
+++ b/src/call_script.cpp
@@ -27,6 +27,8 @@
 #include "userintf.h"
 #include "util.h"
 
+extern char **environ;
+
 extern t_phone *phone;
 
 // Maximum length of the reason value


### PR DESCRIPTION
While glibc includes a declaration of `environ` within `unistd.h`, this is not always the case for other libc instances; POSIX states that `environ` "must be declared by the user if it is to be used directly"¹.

This fixes a build failure on FreeBSD reported at
https://github.com/LubosD/twinkle/pull/305#issuecomment-1284438267

 ¹ https://pubs.opengroup.org/onlinepubs/9699919799/