### PR TITLE
Replace `uint` and `ulong` with standard types

### DIFF
--- a/src/gui/idlesession_inhibitor.cpp
+++ b/src/gui/idlesession_inhibitor.cpp
@@ -166,7 +166,7 @@ void IdleSessionInhibitor::onAsyncReply(QDBusPendingCallWatcher *call)
 	}
 	case request_busy: {
 		// Reply to "Inhibit" has a cookie as return value
-		QDBusPendingReply<uint> reply = *call;
+		QDBusPendingReply<unsigned int> reply = *call;
 
 		if (reply.isError()) {
 			issueWarning(tr("D-Bus: Reply: Error: %1").arg(reply.error().message()));

--- a/src/gui/messageform.cpp
+++ b/src/gui/messageform.cpp
@@ -649,7 +649,7 @@ void MessageForm::toAddressChanged(const QString &address)
 /** Show the size of the typed message */
 void MessageForm::showMessageSize()
 {
-	uint len = msgLineEdit->text().length();
+	unsigned int len = msgLineEdit->text().length();
 	
 	QString s(tr("Size"));
 	s += ": ";

--- a/src/parser/parser.yxx
+++ b/src/parser/parser.yxx
@@ -50,7 +50,7 @@ void yyerror(const char *s);
 
 %union {
 	int			yyt_int;
-	ulong			yyt_ulong;
+	unsigned long		yyt_ulong;
 	float			yyt_float;
 	string			*yyt_str;
 	t_parameter		*yyt_param;

--- a/src/util.h
+++ b/src/util.h
@@ -44,7 +44,7 @@ string float2str(float f, int precision);
 string int2str(int i, const char *format);
 string int2str(int i);
 
-// Convert a ulong to a string. format is a printf format
+// Convert an unsigned long to a string. format is a printf format
 string ulong2str(unsigned long i, const char *format);
 string ulong2str(unsigned long i);
 


### PR DESCRIPTION
The old `uint` and `ulong` types, although provided for compatibility by glibc, are not always found in other libc instances.  This was reported to cause a build failure on FreeBSD¹.

 ¹ https://github.com/LubosD/twinkle/pull/305#issuecomment-1285025978