### PR TITLE
Replace old `PTHREAD_MUTEX_RECURSIVE_NP` with `PTHREAD_MUTEX_RECURSIVE`

### DIFF
--- a/src/threads/mutex.cpp
+++ b/src/threads/mutex.cpp
@@ -36,7 +36,7 @@ t_mutex::t_mutex(bool recursive) {
 	pthread_mutexattr_init(&attr);
 
 
-	int ret = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP);
+	int ret = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
 	if (ret != 0) throw string(
 		"t_mutex::t_mutex failed to create a recursive mutex.");
 


### PR DESCRIPTION
`PTHREAD_MUTEX_RECURSIVE_NP` was a non-portable (hence the `_NP` suffix) equivalent to `PTHREAD_MUTEX_RECURSIVE` in the LinuxThreads implementation.  Now that this era is long behind us, we can simply start using the standard POSIX name, more likely to be supported elsewhere.  (Under glibc, both have always had the same value anyway.)