### PR TITLE
Prevent our own `gsm.h` from being shadowed

### DIFF
--- a/src/audio/gsm/src/CMakeLists.txt
+++ b/src/audio/gsm/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(libtwinkle-gsm)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../inc)
+# Add this directory *before* others, to avoid our own `gsm.h` being shadowed
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/../inc)
 
 set(LIBTWINKLE_GSM-SRCS
 	add.cpp


### PR DESCRIPTION
`libgsm` is typically installed with a top-level `gsm.h` include file (either as the main file or as a compatibility symlink to `gsm/gsm.h`). If `libgsm` is installed but `WITH_GSM` is disabled, it's possible that this copy will shadow our own when `audio/gsm/src` is being built, depending on how include directories are ordered.

This will typically cause a build failure on systems such as FreeBSD, where `/usr/local/include` is inserted early in the list, such as seen in https://github.com/LubosD/twinkle/pull/305#issuecomment-1285847851.

(While both copies are almost identical, the original one enforces C linkage, which ours does not.)