### PR TITLE
libgsm: Support top-level `gsm.h` as possible alternative to `gsm/gsm.h`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,12 @@ if (WITH_GSM)
 	if (GSM_FOUND)
 		message(STATUS "gsm OK")
 		set(HAVE_GSM TRUE)
+		# Whether we should include <gsm.h> or <gsm/gsm.h>
+		if (GSM_INCLUDE_TOP)
+			set(HAVE_GSM_H TRUE)
+		else (GSM_INCLUDE_TOP)
+			set(HAVE_GSM_GSM_H TRUE)
+		endif (GSM_INCLUDE_TOP)
 
 		include_directories(${GSM_INCLUDE_DIR})
 	else (GSM_FOUND)

--- a/cmake/FindGsm.cmake
+++ b/cmake/FindGsm.cmake
@@ -1,4 +1,13 @@
 FIND_PATH(GSM_INCLUDE_DIR gsm/gsm.h)
+# Some distributions only ship a top-level `gsm.h`
+IF (NOT GSM_INCLUDE_DIR)
+	FIND_PATH(GSM_INCLUDE_DIR gsm.h)
+	IF (GSM_INCLUDE_DIR)
+		# Let the caller know about this alternate location
+		SET(GSM_INCLUDE_TOP TRUE)
+	ENDIF (GSM_INCLUDE_DIR)
+ENDIF (NOT GSM_INCLUDE_DIR)
+
 FIND_LIBRARY(GSM_LIBRARY NAMES gsm)
 
 IF(GSM_INCLUDE_DIR AND GSM_LIBRARY)
@@ -7,7 +16,12 @@ ENDIF(GSM_INCLUDE_DIR AND GSM_LIBRARY)
 
 IF(GSM_FOUND)
 	IF (NOT Gsm_FIND_QUIETLY)
-		MESSAGE(STATUS "Found gsm includes:	${GSM_INCLUDE_DIR}/gsm/gsm.h")
+		IF (GSM_INCLUDE_TOP)
+			SET(gsm_include_file "gsm.h")
+		ELSE (GSM_INCLUDE_TOP)
+			SET(gsm_include_file "gsm/gsm.h")
+		ENDIF (GSM_INCLUDE_TOP)
+		MESSAGE(STATUS "Found gsm includes:	${GSM_INCLUDE_DIR}/${gsm_include_file}")
 		MESSAGE(STATUS "Found gsm library:	${GSM_LIBRARY}")
 	ENDIF (NOT Gsm_FIND_QUIETLY)
 ELSE(GSM_FOUND)

--- a/cmake/FindGsm.cmake
+++ b/cmake/FindGsm.cmake
@@ -7,7 +7,7 @@ ENDIF(GSM_INCLUDE_DIR AND GSM_LIBRARY)
 
 IF(GSM_FOUND)
 	IF (NOT Gsm_FIND_QUIETLY)
-		MESSAGE(STATUS "Found gsm includes:	${GSM_INCLUDE_DIR}/gsm/config.h")
+		MESSAGE(STATUS "Found gsm includes:	${GSM_INCLUDE_DIR}/gsm/gsm.h")
 		MESSAGE(STATUS "Found gsm library:	${GSM_LIBRARY}")
 	ENDIF (NOT Gsm_FIND_QUIETLY)
 ELSE(GSM_FOUND)

--- a/src/audio/audio_decoder.h
+++ b/src/audio/audio_decoder.h
@@ -26,7 +26,11 @@
 
 #ifdef HAVE_GSM
 extern "C" {
+#ifdef HAVE_GSM_GSM_H
 #include <gsm/gsm.h>
+#else
+#include <gsm.h>
+#endif
 }
 #else
 #include "gsm/inc/gsm.h"

--- a/src/audio/audio_encoder.h
+++ b/src/audio/audio_encoder.h
@@ -26,7 +26,11 @@
 
 #ifdef HAVE_GSM
 extern "C" {
+#ifdef HAVE_GSM_GSM_H
 #include <gsm/gsm.h>
+#else
+#include <gsm.h>
+#endif
 }
 #else
 #include "gsm/inc/gsm.h"

--- a/src/audio/audio_tx.h
+++ b/src/audio/audio_tx.h
@@ -33,12 +33,6 @@
 #include "twinkle_rtp_session.h"
 #include "twinkle_config.h"
 
-#ifdef HAVE_GSM
-#include <gsm/gsm.h>
-#else
-#include "gsm/inc/gsm.h"
-#endif
-
 using namespace std;
 using namespace ost;
 

--- a/twinkle_config.h.in
+++ b/twinkle_config.h.in
@@ -6,6 +6,8 @@
 #cmakedefine HAVE_BCG729
 #cmakedefine HAVE_BCG729_ANNEX_B
 #cmakedefine HAVE_GSM
+#cmakedefine HAVE_GSM_H
+#cmakedefine HAVE_GSM_GSM_H
 
 #cmakedefine HAVE_UNISTD_H
 #cmakedefine HAVE_LINUX_TYPES_H


### PR DESCRIPTION
Some distributions (e.g. FreeBSD) ship `libgsm` with a top-level `gsm.h`
instead of `gsm/gsm.h`.
