### PR TITLE
warnings: Silence default Clang warnings

### DIFF
--- a/src/audio/audio_device.cpp
+++ b/src/audio/audio_device.cpp
@@ -309,7 +309,7 @@ void t_oss_io::enable(bool enable_playback, bool enable_recording) {
 void t_oss_io::flush(bool playback_buffer, bool recording_buffer) {
 	for (int i = 0; i < 2; i++) {
 		// i == 0: flush playback buffer, 1: flush recording buffer
-		if (i == 0 && playback_buffer || i == 1 && recording_buffer) {
+		if ((i == 0 && playback_buffer) || (i == 1 && recording_buffer)) {
 			int skip_bytes = ( (i==0) ? play_buffersize : 
 				rec_buffersize) - get_buffer_space(i == 1);
 			if(skip_bytes <= 0) continue;

--- a/src/audio/g72x.cpp
+++ b/src/audio/g72x.cpp
@@ -369,11 +369,12 @@ update(
 		/* UPA1 */
 		/* update predictor pole a[0] */
 		state_ptr->a[0] -= state_ptr->a[0] >> 8;
-		if (dqsez != 0)
+		if (dqsez != 0) {
 			if (pks1 == 0)
 				state_ptr->a[0] += 192;
 			else
 				state_ptr->a[0] -= 192;
+		}
 
 		/* LIMD */
 		a1ul = 15360 - a2p;

--- a/src/dialog.cpp
+++ b/src/dialog.cpp
@@ -3919,6 +3919,9 @@ void t_dialog::timeout(t_line_timer timer) {
 	case LTMR_SESSION_REFRESH:
 	case LTMR_SESSION_EXPIRE:
 		return timeout_session_refresh(timer);
+	default:
+		// We're not dealing with a session timer, so carry on as usual
+		break;
 	}
 
 	switch(state) {

--- a/src/parser/hdr_session_expires.cpp
+++ b/src/parser/hdr_session_expires.cpp
@@ -75,6 +75,9 @@ string t_hdr_session_expires::encode_value(void) const {
 		case REFRESHER_UAC:
 			refresher_str = SE_REFRESHER_UAC;
 			break;
+		case REFRESHER_NONE:
+			// Leave refresher_str empty
+			break;
 	}
 	if (!refresher_str.empty()) {
 		t_parameter r("refresher", refresher_str);

--- a/src/parser/response.cpp
+++ b/src/parser/response.cpp
@@ -207,10 +207,10 @@ bool t_response::is_valid(bool &fatal, string &reason) const {
 }
 
 bool t_response::must_authenticate(void) const {
-	return (code == R_401_UNAUTHORIZED &&
-	        hdr_www_authenticate.is_populated() ||
-	        code == R_407_PROXY_AUTH_REQUIRED &&
-	        hdr_proxy_authenticate.is_populated());
+	return ((code == R_401_UNAUTHORIZED &&
+	         hdr_www_authenticate.is_populated()) ||
+	        (code == R_407_PROXY_AUTH_REQUIRED &&
+	         hdr_proxy_authenticate.is_populated()));
 }
 
 void t_response::get_destination(t_ip_port &ip_port) const {


### PR DESCRIPTION
Compiling under Clang with default options triggers a few warnings that are usually disabled under g++ (namely `-Wdangling-else`, `-Wparentheses` and `-Wswitch`).