### PR TITLE
Add keywords entry in twinkle.desktop file

### DIFF
--- a/twinkle.desktop.in
+++ b/twinkle.desktop.in
@@ -44,3 +44,4 @@ Icon=twinkle
 StartupNotify=true
 Terminal=false
 Categories=Qt;Network;Telephony;
+Keywords=sip;voip;softphone;phone


### PR DESCRIPTION
This patch add a keywords entry in twinkle.desktop file.
See: 
 - https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html
 - https://wiki.gnome.org/Initiatives/GnomeGoals/DesktopFileKeywords