### PR TITLE
Fix french translation mistake

### DIFF
--- a/src/gui/lang/twinkle_fr.ts
+++ b/src/gui/lang/twinkle_fr.ts
@@ -1781,7 +1781,7 @@ Si le SAS est égal, vous devez le confirmer en cliquant sur le clavier pour une
     </message>
     <message>
         <source>&amp;Deregister</source>
-        <translation>Se &amp;déconnecté</translation>
+        <translation>Se &amp;déconnecter</translation>
     </message>
     <message>
         <source>Deregister this device</source>


### PR DESCRIPTION
![Capture d’écran du 2023-11-29 11-34-27](https://github.com/LubosD/twinkle/assets/1822627/78703ea1-91c1-4f25-995f-39af91e678f1)

Under the "Connexion" menu item, "Se déconnecté" is spelled wrong, it should be "Se déconnecter".