### PR TITLE
Fix twinkle hanging after call ends due to ALSA-PulseAudio teardown deadlock

### DIFF
--- a/src/audio/audio_device.cpp
+++ b/src/audio/audio_device.cpp
@@ -383,7 +383,12 @@ t_alsa_io::~t_alsa_io() {
 }
 
 
-bool t_alsa_io::open(const string& device, bool playback, bool capture, bool blocking, int channels, t_audio_sampleformat format, int sample_rate, bool short_latency) 
+void t_alsa_io::drop() {
+	if (pcm_play_ptr) snd_pcm_drop(pcm_play_ptr);
+	if (pcm_rec_ptr) snd_pcm_drop(pcm_rec_ptr);
+}
+
+bool t_alsa_io::open(const string& device, bool playback, bool capture, bool blocking, int channels, t_audio_sampleformat format, int sample_rate, bool short_latency)
 {
 	t_audio_io::open(device, playback, capture, blocking, channels, format, sample_rate,
 		short_latency);

--- a/src/audio/audio_device.h
+++ b/src/audio/audio_device.h
@@ -50,6 +50,10 @@ public:
 	virtual int read(unsigned char* buf, int len) = 0;
 	virtual int write(const unsigned char* buf, int len) = 0;
 	virtual int get_sample_rate(void) const;
+
+	// Called before waiting for audio threads to exit, to unblock any
+	// in-progress read/write so the threads can check their stop flags.
+	virtual void drop() {}
 	
 	static t_audio_io* open(const t_audio_device& dev, bool playback, 
 		bool capture, bool blocking, int channels, t_audio_sampleformat format, 
@@ -100,9 +104,10 @@ public:
 	bool play_buffer_underrun(void);
 	int read(unsigned char* buf, int len);
 	int write(const unsigned char* buf, int len);
+	void drop();
 protected:
-	bool open(const string& device, bool playback, bool capture, bool blocking, 
-		int channels, t_audio_sampleformat format, int sample_rate, 
+	bool open(const string& device, bool playback, bool capture, bool blocking,
+		int channels, t_audio_sampleformat format, int sample_rate,
 		bool short_latency);
 private:
 	struct _snd_pcm *pcm_play_ptr, *pcm_rec_ptr;

--- a/src/audio/audio_rx.cpp
+++ b/src/audio/audio_rx.cpp
@@ -413,6 +413,10 @@ t_audio_rx::~t_audio_rx() {
 
 	if (is_running) {
 		stop_running = true;
+		// Unblock any in-progress snd_pcm_readi so the thread can check
+		// stop_running and exit; without this the nanosleep loop below
+		// spins forever when the ALSA-PulseAudio bridge deadlocks.
+		input_device->drop();
 		do {
 			sleeptimer.tv_sec = 0;
 			sleeptimer.tv_nsec = 10000000;

--- a/src/audio/audio_tx.cpp
+++ b/src/audio/audio_tx.cpp
@@ -158,6 +158,10 @@ t_audio_tx::~t_audio_tx() {
 	
 	if (is_running) {
 		stop_running = true;
+		// Unblock any in-progress snd_pcm_writei so the thread can check
+		// stop_running and exit; without this the nanosleep loop below
+		// spins forever when the ALSA-PulseAudio bridge deadlocks.
+		playback_device->drop();
 		do {
 			sleeptimer.tv_sec = 0;
 			sleeptimer.tv_nsec = 10000000;


### PR DESCRIPTION
When a call ends, ~t_audio_rx() and ~t_audio_tx() set stop_running=true then spin in a nanosleep loop waiting for their threads to set is_running=false. However the audio threads are blocked inside snd_pcm_readi/snd_pcm_writei in the ALSA-PulseAudio bridge (libasound), which deadlocks during teardown when PulseAudio owns the device via the asym pcm.!default ALSA config. The threads never check stop_running and is_running never clears, so both destructors loop forever and twinkle hangs permanently after every call.

Fix by adding a drop() virtual to t_audio_io, overridden in t_alsa_io to call snd_pcm_drop() on both PCM handles. Calling drop() before the wait loop in each destructor unblocks any in-progress snd_pcm_readi/snd_pcm_writei immediately, allowing the threads to reach their stop_running check and exit.